### PR TITLE
When using jQuery.noConflict scrolling to an offscreen target fails

### DIFF
--- a/js/hopscotch-0.1.js
+++ b/js/hopscotch-0.1.js
@@ -1466,7 +1466,7 @@
 
         // Use jQuery if it exists
         else if (hasJquery) {
-          $('body, html').animate({ scrollTop: scrollToVal }, getOption('scrollDuration'), cb);
+          jQuery('body, html').animate({ scrollTop: scrollToVal }, getOption('scrollDuration'), cb);
         }
 
         // Use my crummy setInterval scroll solution if we're using plain, vanilla Javascript.


### PR DESCRIPTION
Very minor change that fixes animation to an offscreen target when jQuery is bound to something other than $.
