### PR TITLE
Changed logic to check for typeof currStepNum. 

### DIFF
--- a/js/hopscotch-0.1.2.js
+++ b/js/hopscotch-0.1.2.js
@@ -1856,7 +1856,7 @@
         return this;
       }
 
-      if (!currStepNum && currTour.id === cookieTourId && typeof cookieTourStep !== undefinedStr) {
+      if (typeof currStepNum === "undefined" && currTour.id === cookieTourId && typeof cookieTourStep !== undefinedStr) {
         currStepNum = cookieTourStep;
       }
       else if (!currStepNum) {


### PR DESCRIPTION
Forcing tour to start at step 0 was not working, logic was checking truthiness of variable failing for 0.

code that didn't work properly

```
hopscotch.startTour(tour, 0);
```

Verified tour still resumes properly
