### PR TITLE
add method to redraw the bubble at a new position

### DIFF
--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -1998,6 +1998,19 @@
     };
 
     /**
+     * refreshBubblePosition
+     *
+     * Tell hopscotch that the position of the current tour element changed
+     * and the bubble therefore needs to be redrawn
+     *
+     * @returns {Object} Hopscotch
+     */
+    this.refreshBubblePosition = function() {
+      bubble.setPosition(getCurrStep());
+      return this;
+    };
+
+    /**
      * listen
      *
      * Adds a callback for one of the event types. Valid event types are:

--- a/test/js/test.hopscotch.js
+++ b/test/js/test.hopscotch.js
@@ -644,6 +644,37 @@ describe('Hopscotch', function() {
       hopscotch.endTour();
     });
   });
+  describe('#refreshBubblePosition', function() {
+    it('recalculates the position of the bubble afer moving the element', function() {
+      hopscotch.startTour({
+        id: 'hopscotch-test-refresh-bubble-position',
+        steps: [
+          {
+            target: 'shopping-list',
+            orientation: 'left',
+            title: 'Shopping List',
+            content: 'It\'s a shopping list'
+          }
+        ]
+      });
+
+      var bubbleDomElement = document.querySelector('.hopscotch-bubble');
+      var bubbleTop = bubbleDomElement.style['top'];
+      var bubbleLeft = bubbleDomElement.style['left'];
+
+      document.getElementById('shopping-list').style.setProperty('margin-top', '100px');
+      document.getElementById('shopping-list').style.setProperty('margin-left', '100px');
+
+      hopscotch.refreshBubblePosition();
+
+      expect(bubbleDomElement.style['top']).to.not.eql(bubbleTop);
+      expect(bubbleDomElement.style['left']).to.not.eql(bubbleLeft);
+      hopscotch.endTour();
+
+      document.getElementById('shopping-list').style.setProperty('margin-top', null);
+      document.getElementById('shopping-list').style.setProperty('margin-left', null);
+    })
+  });
 });
 
 /**


### PR DESCRIPTION
Hi, I am currently implementing  a tour and ran into a problem when trying to add a bubble to elements inside a scrollable area(`overflow:scroll`). Basically the bubble will be drawn at the position where the element is located and not be redrawn on scrolling (and it will also be shown even though the element is invisible, but I can handle this myself). I added a new public method to `hopscotch` to tell it that the element position has changed and the bubble needs to be redrawn called `refreshBubblePosition`. 

Here is a short fiddle demonstrating the problem and my solution: http://jsfiddle.net/TnAKp/.

The test I wrote is basically testing nothing but that the new method can be called. If you want me to change the test to make it actually do something, could you give me an indication on how? 

Thank you and great library!
