### PR TITLE
Fix sessionStorage exceeds quota error in Safari

### DIFF
--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -450,6 +450,8 @@
       }
       else {
         if(hasSessionStorage){
+          //Clear out existing sessionStorage key so the new value we set to cookie gets read.
+          //(If we're here, we've run into an error while trying to write to sessionStorage).
           sessionStorage.removeItem(name);
         }
         if (days) {


### PR DESCRIPTION
Fixes issue #86. We're adding an attempt to write to sessionStorage before we set the hasSessionStorage flag. This catches scenarios where sessionStorage is available but cannot be written to.

I'm also contemplating adding another try/catch block in `setState()` on the theory that the writeability of sessionStorage might change from page load to when we try writing to it later (if in the interim lots of data ends up getting written to sessionStorage). Thoughts?
## Testing Done
- Ran /demo tour in Safari private mode. Verified state was being written to cookie and that no console errors were thrown.
- Existing Mocha tests pass.
