### PR TITLE
Prefer jQuery and Sizzle when searching for a target

### DIFF
--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -342,9 +342,6 @@
       if (result) {
         return result;
       }
-      if (document.querySelector) {
-        return document.querySelector(target);
-      }
       if (hasJquery) {
         result = jQuery(target);
         return result.length ? result[0] : null;
@@ -352,6 +349,9 @@
       if (Sizzle) {
         result = new Sizzle(target);
         return result.length ? result[0] : null;
+      }
+      if (document.querySelector) {
+        return document.querySelector(target);
       }
       // Regex test for id. Following the HTML 4 spec for valid id formats.
       // (http://www.w3.org/TR/html4/types.html#type-id)


### PR DESCRIPTION
`jQuery` (or `Sizzle`) offer some additional functionality. For example I am using the `:has` pseudo class that is not available when using `document.querySelector`. Therefore I think it is reasonable to ignore the performance penalty introduced by jQuery and prefer it over `document.querySelector`. 

An alternative to this would be to allow users to pass a function that returns a dom-element as a selector.
