### PR TITLE
box-sizing: content-box (Issue #75)

### DIFF
--- a/src/less/hopscotch.less
+++ b/src/less/hopscotch.less
@@ -12,6 +12,11 @@ div.hopscotch-bubble {
   font-size: 13px;
   position: absolute;
   z-index: @bubbleZindex;
+  .box-sizing(content-box);
+
+  * {
+    .box-sizing(content-box);
+  }
 
   .background-clip;
 


### PR DESCRIPTION
Assume default `box-sizing: content-box` for hopscotch bubble and child elements, unless overridden by a later selector. This allows Hopscotch to play nicely with Bootstrap 3 and any other CSS frameworks or resets that may apply `box-sizing: border-box` to the whole page.

Tested locally using `/demo` page by getting latest version of Bootstrap 3 and replacing Bootstrap 2 with it.
