### PR TITLE
BugIssue97: Callbacks on callouts do not work

### DIFF
--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -1119,6 +1119,9 @@
         if (opt.target) {
           callout.render(opt, null, function() {
             callout.show();
+            if (opt.onShow) {
+              utils.invokeCallback(opt.onShow);
+            }
           });
         }
       }


### PR DESCRIPTION
For now adding only the onShow callback call which will work only with registerHelper and specified in the callout json. The listen will not work, an issue which will get fixed as part of an upcoming refactor.
