### PR TITLE
#116 Revert defuault z-index to empty vs auto

### DIFF
--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -788,7 +788,7 @@
       }
 
       // Set z-index and arrow placement
-      el.style.zIndex = (typeof step.zindex === 'number') ? step.zindex : 'auto';
+      el.style.zIndex = (typeof step.zindex === 'number') ? step.zindex : '';
       this._setArrow(step.placement);
 
       // Set bubble positioning

--- a/test/index.html
+++ b/test/index.html
@@ -24,7 +24,7 @@
 
   <script src="../tmp/js/hopscotch.min.js"></script>
   <script src="../node_modules/jquery/dist/jquery.min.js"></script>
-  <script src="../node_modules/sinon/pkg/sinon-1.9.0.js"></script>
+  <script src="../node_modules/sinon/pkg/sinon-1.9.1.js"></script>
   <script src="./js/test.hopscotch.js"></script>
 
   <div id="shopping-list">

--- a/test/js/test.hopscotch.js
+++ b/test/js/test.hopscotch.js
@@ -926,7 +926,8 @@ describe('HopscotchBubble', function() {
 
       hopscotch.nextStep();
       bubble = document.querySelector('.hopscotch-bubble');
-      expect(bubble.style.zIndex).to.be('auto');
+      expect(bubble.style.zIndex).to.be('');
+      expect($(bubble).css("z-index")).to.be('999999');
 
       hopscotch.endTour();
     });


### PR DESCRIPTION
Set z-index to an empty string if it is not provided in config. This will allow for z-index specified in CSS to apply.

Also updated to the newer version of sinon and updated unit test to test this case.
