### PR TITLE
GH-40 NextOnTarget Click event not always removed

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -178,7 +178,11 @@ module.exports = function(grunt) {
     },
     mocha : {
       test : {
-        src:['<%=paths.test%>/index.html']
+        src:['<%=paths.test%>/index.html'],
+        options: {
+          log: true,
+          logErrors: true
+        }
       }
     },
     shell: {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "grunt-contrib-less": "~0.9.0",
     "grunt-contrib-watch": "~0.5.1",
     "grunt-contrib-compress": "~0.6.0",
-    "grunt-mocha": "~0.4.10",
+    "grunt-mocha": "~0.4.11",
     "expect.js": "~0.2.0",
     "jquery": "~2.1.0",
     "grunt-bump": "~0.0.13",


### PR DESCRIPTION
Remove on click listener with nextOnTargetClick callback for following cases:
- changing step with nextStep or prevStep call (removeEvtListener in changeStep function)
- changing step directly via showStep call (removeEvtListener in showStepHelper function)
- ending tour via closeTour call or clicking on close button (removeEvtListener inside endTour function)

Additionally, removing few unused variables throughout the code.
