### PR TITLE
GH-111: refreshBubblePosition updates all known callouts

### DIFF
--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -1153,7 +1153,8 @@
    * @constructor
    */
   HopscotchCalloutManager = function() {
-    var callouts = {};
+    var callouts = {},
+        calloutOpts = {};
 
     /**
      * createCallout
@@ -1176,6 +1177,7 @@
         opt.isTourBubble = false;
         callout = new HopscotchBubble(opt);
         callouts[opt.id] = callout;
+        calloutOpts[opt.id] = opt;
         if (opt.target) {
           callout.render(opt, null, function() {
             callout.show();
@@ -1229,9 +1231,34 @@
       var callout = callouts[id];
 
       callouts[id] = null;
+      calloutOpts[id] = null;
       if (!callout) { return; }
 
       callout.destroy();
+    };
+
+    /**
+     * refreshCalloutPositions
+     *
+     * Refresh the positions for all callouts known by the
+     * callout manager. Typically you'll use
+     * hopscotch.refreshBubblePosition() to refresh ALL
+     * bubbles instead of calling this directly.
+     */
+    this.refreshCalloutPositions = function(){
+      var calloutId,
+          callout,
+          opts;
+
+      for (calloutId in callouts) {
+        if (callouts.hasOwnProperty(calloutId) && calloutOpts.hasOwnProperty(calloutId)) {
+          callout = callouts[calloutId];
+          opts = calloutOpts[calloutId];
+          if(callout && opts){
+            callout.setPosition(opts);
+          }
+        }
+      }
     };
   };
 
@@ -1306,7 +1333,7 @@
     getCurrStep = function() {
       var step;
 
-      if (currStepNum < 0 || currStepNum >= currTour.steps.length) {
+      if (!currTour || currStepNum < 0 || currStepNum >= currTour.steps.length) {
         step = null;
       }
       else {
@@ -1996,12 +2023,17 @@
      * refreshBubblePosition
      *
      * Tell hopscotch that the position of the current tour element changed
-     * and the bubble therefore needs to be redrawn
+     * and the bubble therefore needs to be redrawn. Also refreshes position
+     * of all Hopscotch Callouts on the page.
      *
      * @returns {Object} Hopscotch
      */
     this.refreshBubblePosition = function() {
-      bubble.setPosition(getCurrStep());
+      var currStep = getCurrStep();
+      if(currStep){
+        getBubble().setPosition(currStep);
+      }
+      this.getCalloutManager().refreshCalloutPositions();
       return this;
     };
 

--- a/test/js/test.hopscotch.js
+++ b/test/js/test.hopscotch.js
@@ -920,6 +920,32 @@ describe('Hopscotch', function() {
       document.getElementById('shopping-list').style.setProperty('margin-top', null);
       document.getElementById('shopping-list').style.setProperty('margin-left', null);
     });
+
+    it('also runs recalculations for individual callouts', function() {
+      hopscotch.getCalloutManager().createCallout({
+        id: 'test_callout',
+        orientation: 'left',
+        target: 'shopping-list',
+        title: 'Shopping List',
+        content: 'It\'s a shopping list'
+      });
+
+      var bubbleDomElement = document.querySelector('.hopscotch-callout');
+      var bubbleTop = bubbleDomElement.style['top'];
+      var bubbleLeft = bubbleDomElement.style['left'];
+
+      document.getElementById('shopping-list').style.setProperty('margin-top', '100px');
+      document.getElementById('shopping-list').style.setProperty('margin-left', '100px');
+
+      hopscotch.refreshBubblePosition();
+
+      expect(bubbleDomElement.style['top']).to.not.eql(bubbleTop);
+      expect(bubbleDomElement.style['left']).to.not.eql(bubbleLeft);
+      hopscotch.getCalloutManager().removeAllCallouts();
+
+      document.getElementById('shopping-list').style.setProperty('margin-top', null);
+      document.getElementById('shopping-list').style.setProperty('margin-left', null);
+    });
   });
 
   describe('Custom render methods', function(){


### PR DESCRIPTION
Calls to hopscotch.refreshBubblePosition() should also update all callouts. Because this call requires current step information, we additionally cache the opts used to create the HopscotchBubble when we add a new callout. Also fixes error in getCurrStep() when called when no tour is in progress.

Resolves issue #111.
