### PR TITLE
Simple bower config file added.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -249,7 +249,7 @@ module.exports = function(grunt) {
     },
     bump: {
       options: {
-        files: ['package.json'],
+        files: ['package.json', 'bower.json'],
         updateConfigs: ['pkg'],
         push: false,
         commit: true,

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,23 @@
+{
+  "name": "hopscotch",
+  "version": "0.2.3",
+  "authors": [],
+  "description": "A framework to make it easy for developers to add product tours to their pages.",
+  "main": [
+    "./dist/js/hopscotch.js",
+    "./dist/css/hopscotch.css"
+  ],
+  "keywords": [
+    "tour",
+    "linkedin"
+  ],
+  "license": "Apache License",
+  "homepage": "https://github.com/linkedin/hopscotch",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
   "homepage": "https://github.com/linkedin/hopscotch",
   "ignore": [
     "**/.*",
+    "archives",
     "node_modules",
     "bower_components",
     "test",


### PR DESCRIPTION
Bower config file added to make [wiredep](https://github.com/taptapship/wiredep) and other automated builders to work fine, as was mentioned in #63.