### PR TITLE
Issue #138: Check tour & callout IDs for invalid characters

### DIFF
--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -21,6 +21,7 @@
       hasSessionStorage = false,
       isStorageWritable = false,
       document          = window.document,
+      validIdRegEx      = /^[a-zA-Z0-9_-]+$/,
       rtlMatches        = {
         left: 'right',
         right: 'left'
@@ -1170,6 +1171,9 @@
       var callout;
 
       if (opt.id) {
+        if(!validIdRegEx.test(opt.id)) {
+          throw 'Callout ID is using an invalid format. Use alphanumeric, underscores, and/or hyphens only.';
+        }
         if (callouts[opt.id]) {
           throw 'Callout by that id already exists. Please choose a unique id.';
         }
@@ -1812,6 +1816,11 @@
           currStepNum,
           skippedSteps = {},
           self = this;
+
+      // Check validity of tour ID. If invalid, throw an error.
+      if(!tour.id || !validIdRegEx.test(tour.id)) {
+        throw 'Tour ID is using an invalid format. Use alphanumeric, underscores, and/or hyphens only.';
+      }
 
       // loadTour if we are calling startTour directly. (When we call startTour
       // from window onLoad handler, we'll use currTour)

--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -21,7 +21,7 @@
       hasSessionStorage = false,
       isStorageWritable = false,
       document          = window.document,
-      validIdRegEx      = /^[a-zA-Z0-9_-]+$/,
+      validIdRegEx      = /^[a-zA-Z]+[a-zA-Z0-9_-]*$/,
       rtlMatches        = {
         left: 'right',
         right: 'left'
@@ -638,7 +638,7 @@
         left = boundingRect.right + this.opt.arrowWidth;
       }
       else {
-        throw 'Bubble placement failed because step.placement is invalid or undefined!';
+        throw new Error('Bubble placement failed because step.placement is invalid or undefined!');
       }
 
       // SET (OR RESET) ARROW OFFSETS
@@ -803,7 +803,7 @@
       }
       else if(typeof tourSpecificRenderer === 'string'){
         if(!hopscotch.templates || (typeof hopscotch.templates[tourSpecificRenderer] !== 'function')){
-          throw 'Bubble rendering failed - template "' + tourSpecificRenderer + '" is not a function.';
+          throw new Error('Bubble rendering failed - template "' + tourSpecificRenderer + '" is not a function.');
         }
         el.innerHTML = hopscotch.templates[tourSpecificRenderer](opts);
       }
@@ -812,7 +812,7 @@
       }
       else{
         if(!hopscotch.templates || (typeof hopscotch.templates[templateToUse] !== 'function')){
-          throw 'Bubble rendering failed - template "' + templateToUse + '" is not a function.';
+          throw new Error('Bubble rendering failed - template "' + templateToUse + '" is not a function.');
         }
         el.innerHTML = hopscotch.templates[templateToUse](opts);
       }
@@ -1172,10 +1172,10 @@
 
       if (opt.id) {
         if(!validIdRegEx.test(opt.id)) {
-          throw 'Callout ID is using an invalid format. Use alphanumeric, underscores, and/or hyphens only.';
+          throw new Error('Callout ID is using an invalid format. Use alphanumeric, underscores, and/or hyphens only. First character must be a letter.');
         }
         if (callouts[opt.id]) {
-          throw 'Callout by that id already exists. Please choose a unique id.';
+          throw new Error('Callout by that id already exists. Please choose a unique id.');
         }
         opt.showNextButton = opt.showPrevButton = false;
         opt.isTourBubble = false;
@@ -1192,7 +1192,7 @@
         }
       }
       else {
-        throw 'Must specify a callout id.';
+        throw new Error('Must specify a callout id.');
       }
       return callout;
     };
@@ -1819,7 +1819,7 @@
 
       // Check validity of tour ID. If invalid, throw an error.
       if(!tour.id || !validIdRegEx.test(tour.id)) {
-        throw 'Tour ID is using an invalid format. Use alphanumeric, underscores, and/or hyphens only.';
+        throw new Error('Tour ID is using an invalid format. Use alphanumeric, underscores, and/or hyphens only. First character must be a letter.');
       }
 
       // loadTour if we are calling startTour directly. (When we call startTour
@@ -1831,7 +1831,7 @@
 
       if (typeof stepNum !== undefinedStr) {
         if (stepNum >= currTour.steps.length) {
-          throw 'Specified step number out of bounds.';
+          throw new Error('Specified step number out of bounds.');
         }
         currStepNum = stepNum;
       }

--- a/test/js/test.hopscotch.js
+++ b/test/js/test.hopscotch.js
@@ -156,7 +156,7 @@ describe('Hopscotch', function() {
     });
 
     it('should reject tour IDs that include invalid characters', function(){
-      try {
+      expect(function(){
         hopscotch.startTour({
           id: '(this is a bad tour id!)',
           steps: [
@@ -168,18 +168,13 @@ describe('Hopscotch', function() {
             }
           ]
         });
-      }
-      catch (e) {
-        expect(true).toBeTruthy();
-        hopscotch.endTour();
-        return;
-      }
-      expect(false).toBeTruthy();
+      }).toThrow(new Error('Tour ID is using an invalid format. Use alphanumeric, underscores, and/or hyphens only. First character must be a letter.'))
+
       hopscotch.endTour();
     });
 
     it('should throw an exception when trying to start the tour at a non-existent step', function() {
-      try {
+      expect(function(){
         hopscotch.startTour({
           id: 'hopscotch-test-tour',
           steps: [
@@ -191,13 +186,8 @@ describe('Hopscotch', function() {
             }
           ]
         }, 10);
-      }
-      catch (e) {
-        expect(true).toBeTruthy();
-        hopscotch.endTour();
-        return;
-      }
-      expect(false).toBeTruthy();
+      }).toThrow(new Error('Specified step number out of bounds.'));
+
       hopscotch.endTour();
     });
 
@@ -1904,7 +1894,7 @@ describe('HopscotchCalloutManager', function() {
     it('should reject callout IDs that contain invalid characters', function() {
       var mgr = hopscotch.getCalloutManager();
 
-      try {
+      expect(function(){
         mgr.createCallout({
           id: '(this is an invalid callout id!)',
           target: 'shopping-list',
@@ -1912,13 +1902,8 @@ describe('HopscotchCalloutManager', function() {
           title: 'Shopping List Callout',
           content: 'It\'s a shopping list'
         });
-      }
-      catch (e) {
-        expect(true).toBeTruthy();
-        hopscotch.endTour();
-        return;
-      }
-      expect(false).toBeTruthy();
+      }).toThrow(new Error('Callout ID is using an invalid format. Use alphanumeric, underscores, and/or hyphens only. First character must be a letter.'));
+
       hopscotch.endTour();
     });
     it('should reject callouts with the same ID as another', function() {
@@ -1932,7 +1917,7 @@ describe('HopscotchCalloutManager', function() {
         content: 'It\'s a shopping list'
       });
 
-      try {
+      expect(function(){
         mgr.createCallout({
           id: 'my-new-callout',
           target: 'shopping-list',
@@ -1940,13 +1925,8 @@ describe('HopscotchCalloutManager', function() {
           title: 'Shopping List Callout',
           content: 'It\'s a shopping list'
         });
-      }
-      catch (e) {
-        expect(true).toBeTruthy();
-        hopscotch.endTour();
-        return;
-      }
-      expect(false).toBeTruthy();
+      }).toThrow(new Error('Callout by that id already exists. Please choose a unique id.'));
+
       hopscotch.endTour();
     });
   });

--- a/test/js/test.hopscotch.js
+++ b/test/js/test.hopscotch.js
@@ -155,6 +155,29 @@ describe('Hopscotch', function() {
       expect(hopscotch.getCurrStepNum()).toBe(1);
     });
 
+    it('should reject tour IDs that include invalid characters', function(){
+      try {
+        hopscotch.startTour({
+          id: '(this is a bad tour id!)',
+          steps: [
+            {
+              target: 'shopping-list',
+              orientation: 'left',
+              title: 'Shopping List',
+              content: 'It\'s a shopping list'
+            }
+          ]
+        });
+      }
+      catch (e) {
+        expect(true).toBeTruthy();
+        hopscotch.endTour();
+        return;
+      }
+      expect(false).toBeTruthy();
+      hopscotch.endTour();
+    });
+
     it('should throw an exception when trying to start the tour at a non-existent step', function() {
       try {
         hopscotch.startTour({
@@ -1877,6 +1900,54 @@ describe('HopscotchCalloutManager', function() {
       expect(callout.destroy).toBeTruthy();
       expect(callout.setPosition).toBeTruthy();
       mgr.removeCallout('shopping-callout');
+    });
+    it('should reject callout IDs that contain invalid characters', function() {
+      var mgr = hopscotch.getCalloutManager();
+
+      try {
+        mgr.createCallout({
+          id: '(this is an invalid callout id!)',
+          target: 'shopping-list',
+          orientation: 'left',
+          title: 'Shopping List Callout',
+          content: 'It\'s a shopping list'
+        });
+      }
+      catch (e) {
+        expect(true).toBeTruthy();
+        hopscotch.endTour();
+        return;
+      }
+      expect(false).toBeTruthy();
+      hopscotch.endTour();
+    });
+    it('should reject callouts with the same ID as another', function() {
+      var mgr = hopscotch.getCalloutManager();
+
+      mgr.createCallout({
+        id: 'my-new-callout',
+        target: 'shopping-list',
+        orientation: 'left',
+        title: 'Shopping List Callout',
+        content: 'It\'s a shopping list'
+      });
+
+      try {
+        mgr.createCallout({
+          id: 'my-new-callout',
+          target: 'shopping-list',
+          orientation: 'left',
+          title: 'Shopping List Callout',
+          content: 'It\'s a shopping list'
+        });
+      }
+      catch (e) {
+        expect(true).toBeTruthy();
+        hopscotch.endTour();
+        return;
+      }
+      expect(false).toBeTruthy();
+      hopscotch.endTour();
     });
   });
 });


### PR DESCRIPTION
Per #138, Tour IDs (and callout IDs) should only support alphanumeric characters, underscores, and dashes. Also adds unit tests to ensure `hopscotch.startTour()` and `HopscotchCalloutManager.createCallout()` throw an error when invalid IDs are used.