### PR TITLE
package.json: switch main file to 'dist/js/hopscotch.js'

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hopscotch",
   "version": "0.2.3",
   "description": "A framework to make it easy for developers to add product tours to their pages.",
-  "main": "Gruntfile.js",
+  "main": "dist/js/hopscotch.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
This is needed for #150, so CommonJS users can include the library as var hopscotch = require('hopscotch');