### PR TITLE
Add .npmignore file and use dist/js/hopscotch.min.js as main in package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+.*
+*.iml
+tmp
+test
+demo
+archives
+bower.json

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hopscotch",
   "version": "0.2.3",
   "description": "A framework to make it easy for developers to add product tours to their pages.",
-  "main": "dist/js/hopscotch.js",
+  "main": "dist/js/hopscotch.min.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Hopefully last change towards resolving #150. 

This PR adds `.npmignore` file which will exclude all files and folders that are needed for development of hopscotch only. `npm install` of hopscotch will pull down these files and folders:

```console
  - node_modules
    - hopscotch
      - dist/
      - src/
      - CHANGELOG.md
      - CONTRIBUTING.md
      - LICENSE
      - README.md
      - package.json
```

`dist` folder contains all files necessary for using hopscotch (compiled js, css and images). I've also kept `src` folder in case people are customizing look and feel and need `*.less` files.

This PR also updates `main` to be the minified javascript distribution of hopscotch. 