### PR TITLE
Hide previous button on first step, even if steps are skipped.

### DIFF
--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -777,7 +777,7 @@
           stepNum: this._getStepI18nNum(this._getStepNum(idx))
         },
         buttons:{
-          showPrev: (utils.valOrDefault(step.showPrevButton, this.opt.showPrevButton) && (idx > 0)),
+          showPrev: (utils.valOrDefault(step.showPrevButton, this.opt.showPrevButton) && (this._getStepNum(idx) > 0)),
           showNext: utils.valOrDefault(step.showNextButton, this.opt.showNextButton),
           showCTA: utils.valOrDefault((step.showCTAButton && step.ctaLabel), false),
           ctaLabel: step.ctaLabel,

--- a/test/js/test.hopscotch.js
+++ b/test/js/test.hopscotch.js
@@ -1569,18 +1569,32 @@ describe('HopscotchBubble', function() {
       var $el,
       tour = {
         id: 'hopscotch-test-tour',
+        showPrevButton: true,
         steps: [
           {
             target: 'shopping-list',
             placement: 'left',
             title: 'Shopping List',
             content: 'It\'s a shopping list',
-            showPrevBtn: false
+          },
+          {
+            target: 'shopping-list',
+            placement: 'left',
+            title: 'Shopping List',
+            content: 'It\'s a shopping list',
+            showPrevButton: false
+          },
+          {
+            target: 'shopping-list',
+            placement: 'left',
+            title: 'Shopping List',
+            content: 'It\'s a shopping list',
           }
         ]
       };
 
       hopscotch.startTour(tour);
+      hopscotch.nextStep();
       $el = $('.hopscotch-prev');
       expect($el.length).toBe(0);
       hopscotch.endTour();
@@ -1603,6 +1617,131 @@ describe('HopscotchBubble', function() {
 
       hopscotch.startTour(tour);
       $el = $('.hopscotch-next');
+      expect($el.length).toBe(0);
+      hopscotch.endTour();
+    });
+
+    it('Should hide Previous button on first step', function(){
+      var $el;
+      hopscotch.startTour({
+        id: 'hopscotch-test-tour-prev-btn',
+        showPrevButton: true,
+        steps: [
+          {
+            target: 'shopping-list',
+            placement: 'left',
+            title: 'Shopping List',
+            content: 'It\'s a shopping list'
+          },
+          {
+            target: 'jasmine',
+            placement: 'top',
+            title: 'Jasmine',
+            content: 'It\'s Jasmine'
+          },
+          {
+            target: 'jasmine',
+            placement: 'top',
+            title: 'Jasmine',
+            content: 'It\'s Jasmine'
+          }
+        ]
+      });
+      $el = $('.hopscotch-prev');
+      expect($el.length).toBe(0);
+      hopscotch.endTour();
+    });
+
+    it('Should show Previous button on second step onward (if enabled)', function(){
+      var $el;
+      hopscotch.startTour({
+        id: 'hopscotch-test-tour-prev-btn',
+        showPrevButton: true,
+        steps: [
+          {
+            target: 'shopping-list',
+            placement: 'left',
+            title: 'Shopping List',
+            content: 'It\'s a shopping list'
+          },
+          {
+            target: 'jasmine',
+            placement: 'top',
+            title: 'Jasmine',
+            content: 'It\'s Jasmine'
+          },
+          {
+            target: 'jasmine',
+            placement: 'top',
+            title: 'Jasmine',
+            content: 'It\'s Jasmine'
+          }
+        ]
+      });
+      hopscotch.nextStep();
+      $el = $('.hopscotch-prev');
+      expect($el.length).toBe(1);
+      hopscotch.endTour();
+    });
+
+    it('Should show Previous button on second step onward (if enabled), even if starting in middle', function(){
+      var $el;
+      hopscotch.startTour({
+        id: 'hopscotch-test-tour-prev-btn',
+        showPrevButton: true,
+        steps: [
+          {
+            target: 'shopping-list',
+            placement: 'left',
+            title: 'Shopping List',
+            content: 'It\'s a shopping list'
+          },
+          {
+            target: 'jasmine',
+            placement: 'top',
+            title: 'Jasmine',
+            content: 'It\'s Jasmine'
+          },
+          {
+            target: 'jasmine',
+            placement: 'top',
+            title: 'Jasmine',
+            content: 'It\'s Jasmine'
+          }
+        ]
+      }, 1);
+      $el = $('.hopscotch-prev');
+      expect($el.length).toBe(1);
+      hopscotch.endTour();
+    });
+
+    it('Should hide Previous button on first shown step (if steps are skipped)', function(){
+      var $el;
+      hopscotch.startTour({
+        id: 'hopscotch-test-tour-prev-btn',
+        showPrevButton: true,
+        steps: [
+          {
+            target: 'this-totally-does-not-exist',
+            placement: 'left',
+            title: 'Shopping List',
+            content: 'It\'s a shopping list'
+          },
+          {
+            target: 'jasmine',
+            placement: 'top',
+            title: 'Jasmine',
+            content: 'It\'s Jasmine'
+          },
+          {
+            target: 'jasmine',
+            placement: 'top',
+            title: 'Jasmine',
+            content: 'It\'s Jasmine'
+          }
+        ]
+      });
+      $el = $('.hopscotch-prev');
       expect($el.length).toBe(0);
       hopscotch.endTour();
     });


### PR DESCRIPTION
Previous button's visibility should reflect skipped steps. Also, fix unit tests related to skip button.

Resolves #161.