### PR TITLE
documentIsReady is when document.readyState is complete

### DIFF
--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -318,7 +318,7 @@
     },
 
     documentIsReady: function() {
-      return document.readyState === 'complete' || document.readyState === 'interactive';
+      return document.readyState === 'complete';
     },
 
     /**


### PR DESCRIPTION
Fixes #172

Removing `document.readyState === 'interactive'` since in IE9 and IE10 `document.body` is null in interactive state.