### PR TITLE
Require exisitng target element for stand-alone callouts

### DIFF
--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -1193,19 +1193,20 @@
         if (callouts[opt.id]) {
           throw new Error('Callout by that id already exists. Please choose a unique id.');
         }
+        if (!utils.getStepTarget(opt)) {
+          throw new Error('Must specify existing target element via \'target\' option.');
+        }
         opt.showNextButton = opt.showPrevButton = false;
         opt.isTourBubble = false;
         callout = new HopscotchBubble(opt);
         callouts[opt.id] = callout;
         calloutOpts[opt.id] = opt;
-        if (opt.target) {
-          callout.render(opt, null, function() {
-            callout.show();
-            if (opt.onShow) {
-              utils.invokeCallback(opt.onShow);
-            }
-          });
-        }
+        callout.render(opt, null, function() {
+          callout.show();
+          if (opt.onShow) {
+            utils.invokeCallback(opt.onShow);
+          }
+        });
       }
       else {
         throw new Error('Must specify a callout id.');

--- a/test/js/test.hopscotch.js
+++ b/test/js/test.hopscotch.js
@@ -1016,6 +1016,21 @@ describe('Hopscotch', function() {
 
       hopscotch.endTour();
     });
+
+    it('should throw an exception when stand-alone callout target does not exist', function(){
+      var calloutMgr = hopscotch.getCalloutManager();
+      expect(function(){
+        calloutMgr.createCallout({
+          id: 'hopscotch-callout-test-123',
+          target: 'totally-does-not-exist',
+          placement: 'bottom',
+          title: 'This test is fun!',
+          content: 'This is how we test this library!'
+        });
+      }).toThrow(new Error('Must specify existing target element via \'target\' option.'));
+
+    });
+
   });
 
   describe('Saving state', function() {


### PR DESCRIPTION
Check that target element exits in stand-alone callouts.

This resolves #177 