### PR TITLE
[GH-24] Recover when tour bubble DOM element is destroyed

### DIFF
--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -1316,7 +1316,7 @@
      * @returns {Object} HopscotchBubble
      */
     getBubble = function(setOptions) {
-      if (!bubble) {
+      if (!bubble || !bubble.element || !bubble.element.parentNode) {
         bubble = new HopscotchBubble(opt);
       }
       if (setOptions) {

--- a/test/js/test.hopscotch.js
+++ b/test/js/test.hopscotch.js
@@ -2196,6 +2196,76 @@ describe('HopscotchBubble', function() {
       hopscotch.unregisterHelper(helperName);
     });
   });
+
+  describe('Should recover if bubble DOM element is destroyed', function(){
+    var tourConfig = {
+      id: 'hopscotch-test-tour',
+      steps: [
+        {
+          target: 'shopping-list',
+          placement: 'left',
+          title: 'Shopping List',
+          content: 'It\'s a shopping list'
+        },
+        {
+          target: 'jasmine',
+          placement: 'top',
+          title: 'Jasmine',
+          content: 'It\'s Jasmine'
+        }
+    ]};
+
+    it('should re-create a tour bubble if it\'s dom element is destroyed', function(){
+      var $hBubble;
+
+      hopscotch.startTour(tourConfig);
+
+      //bubble should exist in page DOM
+      $hBubble = $('.hopscotch-bubble');
+      expect($hBubble.length).toEqual(1);
+
+      //destroy the bubble element
+      $hBubble.remove();
+
+      hopscotch.nextStep();
+      $hBubble = $('.hopscotch-bubble');
+      expect($hBubble.length).toEqual(1);
+
+      //destroy the bubble element
+      $hBubble.remove();
+
+      hopscotch.prevStep();
+      $hBubble = $('.hopscotch-bubble');
+      expect($hBubble.length).toEqual(1);
+
+      hopscotch.endTour();
+
+    });
+
+    it('Can stop and re-start tour event when bubbles dom element does not exist', function(){
+      var $hBubble;
+
+      hopscotch.startTour(tourConfig);
+
+      //bubble should exist in page DOM
+      $hBubble = $('.hopscotch-bubble');
+      expect($hBubble.length).toEqual(1);
+
+      //destroy the bubble element
+      $hBubble.remove();
+
+      hopscotch.endTour();
+
+      //restart the tour and make sure that
+      //bubble is created
+      hopscotch.startTour(tourConfig);
+      $hBubble = $('.hopscotch-bubble');
+      expect($hBubble.length).toEqual(1);
+
+      hopscotch.endTour();
+    });
+
+  });
 });
 
 describe('HopscotchCalloutManager', function() {


### PR DESCRIPTION
Resolves #24  

This pill request:
 - Re-creates bubble DOM element if it is destroyed.
 - Added unit tests to test that hopscotch recovers when bubble element is destroyed