### PR TITLE
Add stopPropagation to close event handler to avoid bubbling up

### DIFF
--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -327,6 +327,7 @@
     evtPreventDefault: function(evt) {
       if (evt.preventDefault) {
         evt.preventDefault();
+        evt.stopPropagation();
       }
       else if (event) {
         event.returnValue = false;


### PR DESCRIPTION
I'm using Hopscotch in a Backbone SPA and without an event.stopPropagation on the close event, the page renders the '#' path when closing one of the steps bubbles, breaking the site functionality.

So I think it would be safer to implement that functionality as default, because in the 'onClose' callback, you don't have access to 'event', it is called with no arguments.
That would be another solution, so anyone with my same problem could put the stopPropagation there in the 'onClose' callback.

Thank you.