### PR TITLE
#188: No event called after tour is finished

### DIFF
--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -1665,6 +1665,8 @@
           return this.endTour(true, false);
         }
         changeStepCb.call(this, currStepNum);
+      } else if (currStepNum + direction === currTour.steps.length) {
+        return this.endTour();
       }
 
       return this;


### PR DESCRIPTION
This pull request resolves #188 . Summary of changes:
 - Ending tour when we are on the last step
 - Add unit test to test this case
 - Update all unit tests to use Jasmine spies instead of adding a class to the body element
 - Make sure we clear state after each test by ending tour and removing all callouts
 - Center test markup, so we can actually see HopscotchBubble while testing\debugging