### PR TITLE
option to append hopscotch div to specified element instead of body

### DIFF
--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -1138,7 +1138,7 @@
 
       // Check if appendTo option is on the page
       if (this.opt.appendTo){
-        appendTo = getStepTargetHelper(this.opt.appendTo);
+        appendTo = utils.getStepTargetHelper(this.opt.appendTo);
       }
 
       if (utils.documentIsReady()) {

--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -1064,6 +1064,7 @@
           self            = this,
           resizeCooldown  = false, // for updating after window resize
           onWinResize,
+          appendTo,
           appendToBody,
           children,
           numChildren,
@@ -1134,8 +1135,14 @@
       this.hide();
 
       //Finally, append our new bubble to body once the DOM is ready.
+
+      // Check if appendTo option is on the page
+      if (this.opt.appendTo){
+        appendTo = getStepTargetHelper(this.opt.appendTo);
+      }
+
       if (utils.documentIsReady()) {
-        document.body.appendChild(el);
+        appendTo ? appendTo.appendChild(el) : document.body.appendChild(el);
       }
       else {
         // Moz, webkit, Opera
@@ -1144,7 +1151,7 @@
             document.removeEventListener('DOMContentLoaded', appendToBody);
             window.removeEventListener('load', appendToBody);
 
-            document.body.appendChild(el);
+            appendTo ? appendTo.appendChild(el) : document.body.appendChild(el);
           };
 
           document.addEventListener('DOMContentLoaded', appendToBody, false);
@@ -1155,7 +1162,7 @@
             if (document.readyState === 'complete') {
               document.detachEvent('onreadystatechange', appendToBody);
               window.detachEvent('onload', appendToBody);
-              document.body.appendChild(el);
+              appendTo ? appendTo.appendChild(el) : document.body.appendChild(el);
             }
           };
 

--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -1142,7 +1142,11 @@
       }
 
       if (utils.documentIsReady()) {
-        appendTo ? appendTo.appendChild(el) : document.body.appendChild(el);
+        if (appendTo){
+          appendTo.appendChild(el);
+        } else {
+          document.body.appendChild(el);
+        }
       }
       else {
         // Moz, webkit, Opera
@@ -1151,7 +1155,11 @@
             document.removeEventListener('DOMContentLoaded', appendToBody);
             window.removeEventListener('load', appendToBody);
 
-            appendTo ? appendTo.appendChild(el) : document.body.appendChild(el);
+            if (appendTo){
+              appendTo.appendChild(el);
+            } else {
+              document.body.appendChild(el);
+            }
           };
 
           document.addEventListener('DOMContentLoaded', appendToBody, false);
@@ -1162,7 +1170,11 @@
             if (document.readyState === 'complete') {
               document.detachEvent('onreadystatechange', appendToBody);
               window.detachEvent('onload', appendToBody);
-              appendTo ? appendTo.appendChild(el) : document.body.appendChild(el);
+              if (appendTo){
+                appendTo.appendChild(el);
+              } else {
+                document.body.appendChild(el);
+              }
             }
           };
 

--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -1064,7 +1064,7 @@
           self            = this,
           resizeCooldown  = false, // for updating after window resize
           onWinResize,
-          appendToBody,
+          appendOnLoad,
           children,
           numChildren,
           node,
@@ -1156,27 +1156,27 @@
       else {
         // Moz, webkit, Opera
         if (document.addEventListener) {
-          appendToBody = function() {
-            document.removeEventListener('DOMContentLoaded', appendToBody);
-            window.removeEventListener('load', appendToBody);
+          appendOnLoad = function() {
+            document.removeEventListener('DOMContentLoaded', appendOnLoad);
+            window.removeEventListener('load', appendOnLoad);
             appendEl(el);
           };
 
-          document.addEventListener('DOMContentLoaded', appendToBody, false);
+          document.addEventListener('DOMContentLoaded', appendOnLoad, false);
         }
         // IE
         else {
-          appendToBody = function() {
+          appendOnLoad = function() {
             if (document.readyState === 'complete') {
-              document.detachEvent('onreadystatechange', appendToBody);
-              window.detachEvent('onload', appendToBody);
+              document.detachEvent('onreadystatechange', appendOnLoad);
+              window.detachEvent('onload', appendOnLoad);
               appendEl(el);
             }
           };
 
-          document.attachEvent('onreadystatechange', appendToBody);
+          document.attachEvent('onreadystatechange', appendOnLoad);
         }
-        utils.addEvtListener(window, 'load', appendToBody);
+        utils.addEvtListener(window, 'load', appendOnLoad);
       }
     }
   };

--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -1064,7 +1064,6 @@
           self            = this,
           resizeCooldown  = false, // for updating after window resize
           onWinResize,
-          appendTo,
           appendToBody,
           children,
           numChildren,
@@ -1121,6 +1120,21 @@
         }, 100);
       };
 
+      /**
+       * Append Hopscotch callout to a specific element or the body
+       *
+       * @private
+       */
+      appendEl = function(el) {
+        var appendToEl = utils.getStepTargetHelper(opt.appendTo);
+
+        if (appendToEl) {
+          appendToEl.appendChild(el);
+        } else {
+          document.body.appendChild(el);
+        }
+      };
+
       //Add listener to reset bubble position on window resize
       utils.addEvtListener(window, 'resize', onWinResize);
 
@@ -1136,17 +1150,8 @@
 
       //Finally, append our new bubble to body once the DOM is ready.
 
-      // Check if appendTo option is on the page
-      if (this.opt.appendTo){
-        appendTo = utils.getStepTargetHelper(this.opt.appendTo);
-      }
-
       if (utils.documentIsReady()) {
-        if (appendTo){
-          appendTo.appendChild(el);
-        } else {
-          document.body.appendChild(el);
-        }
+        appendEl(el);
       }
       else {
         // Moz, webkit, Opera
@@ -1154,12 +1159,7 @@
           appendToBody = function() {
             document.removeEventListener('DOMContentLoaded', appendToBody);
             window.removeEventListener('load', appendToBody);
-
-            if (appendTo){
-              appendTo.appendChild(el);
-            } else {
-              document.body.appendChild(el);
-            }
+            appendEl(el);
           };
 
           document.addEventListener('DOMContentLoaded', appendToBody, false);
@@ -1170,11 +1170,7 @@
             if (document.readyState === 'complete') {
               document.detachEvent('onreadystatechange', appendToBody);
               window.detachEvent('onload', appendToBody);
-              if (appendTo){
-                appendTo.appendChild(el);
-              } else {
-                document.body.appendChild(el);
-              }
+              appendEl(el);
             }
           };
 

--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -609,11 +609,12 @@
     setPosition: function(step) {
       var bubbleBoundingHeight,
           bubbleBoundingWidth,
-          boundingRect,
+          position,
           top,
           left,
           arrowOffset,
           verticalLeftPosition,
+          appendToEl   = utils.getStepTargetHelper(this.opt.appendTo),
           targetEl     = utils.getStepTarget(step),
           el           = this.element,
           arrowEl      = this.arrowEl,
@@ -627,25 +628,34 @@
       utils.removeClass(el, 'fade-in-down fade-in-up fade-in-left fade-in-right');
 
       // SET POSITION
-      boundingRect = targetEl.getBoundingClientRect();
+      if (appendToEl) {
+        position = {
+          bottom: targetEl.offsetTop + targetEl.offsetHeight,
+          left: targetEl.offsetLeft,
+          right: targetEl.offsetLeft + targetEl.offsetWidth,
+          top: targetEl.offsetTop
+        };
+      } else {
+        position = targetEl.getBoundingClientRect();
+      }
 
-      verticalLeftPosition = step.isRtl ? boundingRect.right - bubbleBoundingWidth : boundingRect.left;
+      verticalLeftPosition = step.isRtl ? position.right - bubbleBoundingWidth : position.left;
 
       if (step.placement === 'top') {
-        top = (boundingRect.top - bubbleBoundingHeight) - this.opt.arrowWidth;
+        top = (position.top - bubbleBoundingHeight) - this.opt.arrowWidth;
         left = verticalLeftPosition;
       }
       else if (step.placement === 'bottom') {
-        top = boundingRect.bottom + this.opt.arrowWidth;
+        top = position.bottom + this.opt.arrowWidth;
         left = verticalLeftPosition;
       }
       else if (step.placement === 'left') {
-        top = boundingRect.top;
-        left = boundingRect.left - bubbleBoundingWidth - this.opt.arrowWidth;
+        top = position.top;
+        left = position.left - bubbleBoundingWidth - this.opt.arrowWidth;
       }
       else if (step.placement === 'right') {
-        top = boundingRect.top;
-        left = boundingRect.right + this.opt.arrowWidth;
+        top = position.top;
+        left = position.right + this.opt.arrowWidth;
       }
       else {
         throw new Error('Bubble placement failed because step.placement is invalid or undefined!');
@@ -685,14 +695,14 @@
 
       // HORIZONTAL OFFSET
       if (step.xOffset === 'center') {
-        left = (boundingRect.left + targetEl.offsetWidth/2) - (bubbleBoundingWidth / 2);
+        left = (position.left + targetEl.offsetWidth/2) - (bubbleBoundingWidth / 2);
       }
       else {
         left += utils.getPixelValue(step.xOffset);
       }
       // VERTICAL OFFSET
       if (step.yOffset === 'center') {
-        top = (boundingRect.top + targetEl.offsetHeight/2) - (bubbleBoundingHeight / 2);
+        top = (position.top + targetEl.offsetHeight/2) - (bubbleBoundingHeight / 2);
       }
       else {
         top += utils.getPixelValue(step.yOffset);
@@ -1927,7 +1937,7 @@
         bubble = getBubble();
         // TODO: do we still need this call to .hide()? No longer using opt.animate...
         // Leaving it in for now to play it safe
-        bubble.hide(false); // make invisible for boundingRect calculations when opt.animate == true
+        bubble.hide(false); // make invisible for position calculations when opt.animate == true
 
         self.isActive = true;
 

--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -709,13 +709,13 @@
       }
 
       // ADJUST TOP FOR SCROLL POSITION
-      if (!step.fixedElement) {
+      if (!step.fixedElement && !appendToEl) {
         top += utils.getScrollTop();
         left += utils.getScrollLeft();
       }
 
       // ACCOUNT FOR FIXED POSITION ELEMENTS
-      el.style.position = (step.fixedElement ? 'fixed' : 'absolute');
+      el.style.position = (step.fixedElement && !appendToEl ? 'fixed' : 'absolute');
 
       el.style.top = top + 'px';
       el.style.left = left + 'px';

--- a/test/js/test.hopscotch.js
+++ b/test/js/test.hopscotch.js
@@ -134,6 +134,41 @@ describe('Hopscotch', function() {
       hopscotch.endTour();
     });
 
+    it('should create a div for the HopscotchBubble and append to the specified element', function() {
+      var el = document.createElement('div');
+      el.id = 'append-test';
+      document.body.appendChild(el);
+      hopscotch.startTour({
+        id: 'hopscotch-test-tour',
+        steps: [ {
+          target: 'shopping-list',
+          placement: 'left',
+          title: 'Shopping List',
+          content: 'It\'s a shopping list'
+        } ],
+        appendTo: 'append-test'
+      });
+      expect(document.querySelector('.hopscotch-bubble').parentElement).toEqual(el);
+      hopscotch.endTour();
+    });
+
+    it('should create a div for the HopscotchBubble and append to body if appendTo element does not exist', function() {
+      var body = document.body;
+      body.id = 'body-id'
+      hopscotch.startTour({
+        id: 'hopscotch-test-tour',
+        steps: [ {
+          target: 'shopping-list',
+          placement: 'left',
+          title: 'Shopping List',
+          content: 'It\'s a shopping list'
+        } ],
+        appendTo: 'no-element'
+      });
+      expect(document.querySelector('.hopscotch-bubble').parentElement.id).toEqual(body.id);
+      hopscotch.endTour();
+    });
+
     it('should start the tour at the specified step when a step number is supplied as an argument', function() {
       hopscotch.startTour({
         id: 'hopscotch-test-tour',


### PR DESCRIPTION
In some cases, append the entire hopscotch element to the body is undesirable. For example, angular apps use many templates and you don't want the tour bubbles persisting between different views. This PR allows a user to specify an `appendTo` to a tour to specify which element to append the hopscotch element to. If the element doesn't exist, the hopscotch element will be appended to the body.
