### PR TITLE
Deprecated `arrowWidth` config and added unit tests for `xOffset` and `yOffset`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -339,13 +339,19 @@ module.exports = function (grunt) {
   grunt.registerTask(
     'buildESTest',
     'Build hopscotch for testing (jshint, minify js, process less to css)',
-    ['babel:test', 'browserify:test', 'jasmine:testESDev:build']
+    ['babel:test', 'browserify:test']
+    );
+
+  grunt.registerTask(
+    'testES',
+    'Run unit tests against refactored library code',
+    ['buildES', 'buildESTest', 'jasmine:testESDev']
     );
 
   grunt.registerTask(
     'devES',
     'Start test server to allow debugging unminified hopscotch code in a browser',
-    ['buildES', 'buildESTest', 'connect:testServer', 'log:devES', 'watch:esCode']
+    ['buildES', 'buildESTest', 'jasmine:testESDev:build', 'connect:testServer', 'log:devES', 'watch:esCode']
     );
 
   //grunt task aliases
@@ -358,7 +364,7 @@ module.exports = function (grunt) {
   grunt.registerTask(
     'test',
     'Build hopscotch and run unit tests',
-    ['build', 'jasmine:testProd', 'jasmine:coverage']
+    ['build', 'jasmine:testProd', 'jasmine:coverage', 'testES']
     );
 
   grunt.registerTask(

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "grunt-contrib-less": "~0.9.0",
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-eslint": "^17.2.0",
     "grunt-include-replace": "~1.2.0",
     "grunt-template-jasmine-istanbul": "^0.3.0",
     "jquery": "~2.1.0"

--- a/src/es/managers/CalloutPlacementManager.js
+++ b/src/es/managers/CalloutPlacementManager.js
@@ -40,9 +40,9 @@ function setArrowPositionHorizontal(arrowEl, calloutEl, horizontalProp, arrowOff
 let placementStrategies = {
   'top': {
     arrowPlacement: 'down',
-    calculateCalloutPosition(targetElBox, calloutElBox, isRtl, arrowWidth) {
+    calculateCalloutPosition(targetElBox, calloutElBox, arrowElBox, isRtl) {
       let verticalLeftPosition = isRtl ? targetElBox.right - calloutElBox.width : targetElBox.left;
-      let top = (targetElBox.top - calloutElBox.height) - arrowWidth;
+      let top = (targetElBox.top - calloutElBox.height) - arrowElBox.height;
       let left = verticalLeftPosition;
       return { top, left };
     },
@@ -50,9 +50,9 @@ let placementStrategies = {
   },
   'bottom': {
     arrowPlacement: 'up',
-    calculateCalloutPosition(targetElBox, calloutElBox, isRtl, arrowWidth) {
+    calculateCalloutPosition(targetElBox, calloutElBox, arrowElBox, isRtl) {
       let verticalLeftPosition = isRtl ? targetElBox.right - calloutElBox.width : targetElBox.left;
-      let top = targetElBox.bottom + arrowWidth;
+      let top = targetElBox.bottom + arrowElBox.height;
       let left = verticalLeftPosition;
       return { top, left };
     },
@@ -61,9 +61,9 @@ let placementStrategies = {
   'left': {
     arrowPlacement: 'right',
     rtlPlacement: 'right',
-    calculateCalloutPosition(targetElBox, calloutElBox, isRtl, arrowWidth) {
+    calculateCalloutPosition(targetElBox, calloutElBox, arrowElBox, isRtl) {
       let top = targetElBox.top;
-      let left = targetElBox.left - calloutElBox.width - arrowWidth;
+      let left = targetElBox.left - calloutElBox.width - arrowElBox.width;
       return { top, left };
     },
     setArrowPosition: setArrowPositionHorizontal
@@ -71,9 +71,9 @@ let placementStrategies = {
   'right': {
     arrowPlacement: 'left',
     rtlPlacement: 'left',
-    calculateCalloutPosition(targetElBox, calloutElBox, isRtl, arrowWidth) {
+    calculateCalloutPosition(targetElBox, calloutElBox, arrowElBox, isRtl) {
       let top = targetElBox.top;
-      let left = targetElBox.right + arrowWidth;
+      let left = targetElBox.right + arrowElBox.width;
       return { top, left };
     },
     setArrowPosition: setArrowPositionHorizontal
@@ -157,19 +157,26 @@ function positionCallout(callout, placementStrategy) {
 
   let isTargetFixed = isFixedElement(targetEl);
   let targetElBox = targetEl.getBoundingClientRect();
-  let calloutElBox = { width: callout.el.offsetWidth, height: callout.el.offsetHeight };
+  let calloutElBox = callout.el.getBoundingClientRect();
+  let arrowEl = callout.el.querySelector('.hopscotch-arrow');
+  let arrowElBox = arrowEl.getBoundingClientRect();
   let calloutPosition = placementStrategy.calculateCalloutPosition(
     targetElBox,
     calloutElBox,
-    callout.config.get('isRtl'),
-    callout.config.get('arrowWidth')
+    arrowElBox,
+    callout.config.get('isRtl')
     );
   
   //Adjust position if xOffset and yOffset are specified
   //horizontal offset
+  let placement = callout.config.get('placement');
   let xOffset = callout.config.get('xOffset');
   if (xOffset === 'center') {
-    calloutPosition.left = (targetElBox.left + targetEl.offsetWidth / 2) - (calloutElBox.width / 2);
+    if (placement === 'left' || placement === 'right') {
+      throw new Error('Can not use xOffset \'center\' with placement \'left\' or \'right\'. Callout will overlay the target.');
+    } else {
+      calloutPosition.left = (targetElBox.left + targetEl.offsetWidth / 2) - (calloutElBox.width / 2);
+    }
   }
   else {
     calloutPosition.left += Utils.getPixelValue(xOffset);
@@ -177,7 +184,11 @@ function positionCallout(callout, placementStrategy) {
   //vertical offset
   let yOffset = callout.config.get('yOffset');
   if (yOffset === 'center') {
-    calloutPosition.top = (targetElBox.top + targetEl.offsetHeight / 2) - (calloutElBox.height / 2);
+    if (placement === 'top' || placement === 'bottom') {
+      throw new Error('Can not use yOffset \'center\' with placement \'top\' or \'bottom\'. Callout will overlay the target.');
+    } else {
+      calloutPosition.top = (targetElBox.top + targetEl.offsetHeight / 2) - (calloutElBox.height / 2);
+    }
   }
   else {
     calloutPosition.top += Utils.getPixelValue(yOffset);
@@ -238,15 +249,18 @@ let CalloutPlacementManager = {
     if (!placementStrategy) {
       throw new Error('Bubble placement failed because placement is invalid or undefined!');
     }
+
     //if callout is RTL enabled we need to adjust
     //placement and xOffset values
     placementStrategy = adjustPlacementForRtl(callout, placementStrategy);
-    //adjust position of the callout element
-    //to be placed next to the target 
-    positionCallout(callout, placementStrategy);
+
     //update callout's arrow to point
     //in the direction of the target element
     positionArrow(callout, placementStrategy);
+
+    //adjust position of the callout element
+    //to be placed next to the target 
+    positionCallout(callout, placementStrategy);
   }
 };
 export default CalloutPlacementManager;

--- a/src/es/managers/PlacementManager.js
+++ b/src/es/managers/PlacementManager.js
@@ -173,7 +173,7 @@ function positionCallout(callout, placementStrategy) {
   let xOffset = callout.config.get('xOffset');
   if (xOffset === 'center') {
     if (placement === 'left' || placement === 'right') {
-      throw new Error('Can not use xOffset \'center\' with placement \'left\' or \'right\'. Callout will overlay the target.');
+      Utils.logError('Can not use xOffset \'center\' with placement \'left\' or \'right\'. Callout will overlay the target.');
     } else {
       calloutPosition.left = (targetElBox.left + targetEl.offsetWidth / 2) - (calloutElBox.width / 2);
     }
@@ -185,7 +185,7 @@ function positionCallout(callout, placementStrategy) {
   let yOffset = callout.config.get('yOffset');
   if (yOffset === 'center') {
     if (placement === 'top' || placement === 'bottom') {
-      throw new Error('Can not use yOffset \'center\' with placement \'top\' or \'bottom\'. Callout will overlay the target.');
+      Utils.logError('Can not use yOffset \'center\' with placement \'top\' or \'bottom\'. Callout will overlay the target.');
     } else {
       calloutPosition.top = (targetElBox.top + targetEl.offsetHeight / 2) - (calloutElBox.height / 2);
     }

--- a/src/es/managers/PlacementManager.js
+++ b/src/es/managers/PlacementManager.js
@@ -1,7 +1,7 @@
 import * as Utils from '../modules/utils.js';
 
 /*
-  CalloutPlacementManager handles evertyhing related to callout positioning,
+  PlacementManager handles evertyhing related to callout positioning,
   including arrow position, placement of the callout, respositioning of the callout
   for responsive designs, etc.
 */
@@ -242,7 +242,7 @@ function isFixedElement(el) {
 /* END PRIVATE FUNCTIONS AND VARIABLES FOR THIS MODULE */
 /* PUBLIC INTERFACE AND EXPORT STATEMENT FOR THIS MODULE */
 
-let CalloutPlacementManager = {
+let PlacementManager = {
   setCalloutPosition(callout) {
     //make sure that placement is set to a valid value
     let placementStrategy = placementStrategies[callout.config.get('placement')];
@@ -263,5 +263,5 @@ let CalloutPlacementManager = {
     positionCallout(callout, placementStrategy);
   }
 };
-export default CalloutPlacementManager;
+export default PlacementManager;
 /* END PUBLIC INTERFACE AND EXPORT STATEMENT FOR THIS MODULE */

--- a/src/es/modules/callout.js
+++ b/src/es/modules/callout.js
@@ -1,6 +1,6 @@
 import Config from './config.js';
 import TemplateManager from '../managers/TemplateManager.js';
-import CalloutPlacementManager from '../managers/CalloutPlacementManager.js';
+import PlacementManager from '../managers/PlacementManager.js';
 import * as Utils from './utils.js';
 
 //Abstract base class for callouts
@@ -16,7 +16,7 @@ export class Callout {
       this.getRenderData()
       );
     document.body.appendChild(this.el);
-    CalloutPlacementManager.setCalloutPosition(this);
+    PlacementManager.setCalloutPosition(this);
   }
   show() {
     Utils.removeClass(this.el, 'hide');

--- a/src/es/modules/utils.js
+++ b/src/es/modules/utils.js
@@ -109,3 +109,14 @@ export function removeClass(domEl, strClassNamesToRemove) {
 
   domEl.className = domClasses.replace(/^\s+|\s+$/g, '');
 }
+
+/**
+ * logError
+ * ===========
+ * Log error to the console
+ */
+export function logError(message) {
+  if(typeof console !== 'undefined' && typeof console.error !== 'undefined') {
+    console.error(message);
+  }
+}

--- a/src/es/modules/utils.js
+++ b/src/es/modules/utils.js
@@ -6,8 +6,13 @@ export function isIdValid(id) {
 
 export function getPixelValue(val) {
   let valType = typeof val;
-  if (valType === 'number') { return val; }
-  if (valType === 'string') { return parseInt(val, 10); }
+  if (valType === 'number') {
+    return val;
+  }
+  if (valType === 'string') {
+    let result = parseInt(val, 10); 
+    return isNaN(result) ? 0 : result;
+  }
   return 0;
 }
 

--- a/src/less/core.less
+++ b/src/less/core.less
@@ -121,10 +121,8 @@ div.hopscotch-bubble {
 
   .hopscotch-bubble-arrow-container {
     @arrowWidth: 17px;
+    @arrowOffset: -1 * (@bubbleBorderWidth + @arrowWidth);
     position: absolute;
-
-    width: @arrowWidth*2;
-    height: @arrowWidth*2;
 
     .hopscotch-bubble-arrow,
     .hopscotch-bubble-arrow-border {
@@ -133,8 +131,10 @@ div.hopscotch-bubble {
     }
 
     &.up {
-      top: 0 - @arrowWidth - @bubbleBorderWidth;
+      top: @arrowOffset;
       left: @bubbleCornerRadius;
+      width: @arrowWidth * 2;
+      height: @arrowWidth;
 
       .hopscotch-bubble-arrow {
         border-bottom: @arrowWidth solid @bubbleColor;
@@ -151,8 +151,10 @@ div.hopscotch-bubble {
       }
     }
     &.down {
-      bottom: 0 - @arrowWidth*2 - @bubbleBorderWidth;
+      bottom: @arrowOffset;
       left: @bubbleCornerRadius;
+      width: @arrowWidth * 2;
+      height: @arrowWidth;
 
       .hopscotch-bubble-arrow {
         border-top:   @arrowWidth solid @bubbleColor;
@@ -170,7 +172,9 @@ div.hopscotch-bubble {
     }
     &.left {
       top: @bubbleCornerRadius;
-      left: 0 - @arrowWidth - @bubbleBorderWidth;
+      left: @arrowOffset;
+      width: @arrowWidth;
+      height: @arrowWidth * 2;
 
       .hopscotch-bubble-arrow {
         border-bottom: @arrowWidth solid transparent;
@@ -189,7 +193,9 @@ div.hopscotch-bubble {
     }
     &.right {
       top: @bubbleCornerRadius;
-      right: 0 - @arrowWidth*2 - @bubbleBorderWidth;
+      right: @arrowOffset;
+      width: @arrowWidth;
+      height: @arrowWidth * 2;
 
       .hopscotch-bubble-arrow {
         border-bottom: @arrowWidth solid transparent;

--- a/test/es/specs/placement.spec.js
+++ b/test/es/specs/placement.spec.js
@@ -334,30 +334,30 @@ describe('Callout offsets', () => {
       PlacementTestUtils.verifyXOffset(targetEl, 'bottom', 'center');
     });
 
-    it('Callout with placement \'left\' and xOffset \'center\' should throw an exception', () => {
-      expect(() => {
-        calloutManager.createCallout({
-          id: 'xOffset-left',
-          target: targetEl,
-          placement: 'left',
-          title: 'Callout with xOffset',
-          content: 'Awesome callout!',
-          xOffset: 'center'
-        });
-      }).toThrow(new Error('Can not use xOffset \'center\' with placement \'left\' or \'right\'. Callout will overlay the target.'));
+    it('Callout with placement \'left\' and xOffset \'center\' should default to \'xOffset\' of 0px', () => {
+      calloutManager.createCallout({
+        id: 'xOffset-left',
+        target: targetEl,
+        placement: 'left',
+        title: 'Callout with xOffset',
+        content: 'Awesome callout!',
+        xOffset: 'center'
+      });
+      //Can not use xOffset 'center' with placement 'left' or 'right'. Callout will overlay the target.
+      PlacementTestUtils.verifyXOffset(targetEl, 'left', 0);
     });
 
-    it('Callout with placement \'right\' and xOffset \'center\' should throw an exception', () => {
-      expect(() => {
-        calloutManager.createCallout({
-          id: 'xOffset-right',
-          target: targetEl,
-          placement: 'right',
-          title: 'Callout with xOffset',
-          content: 'Awesome callout!',
-          xOffset: 'center'
-        });
-      }).toThrow(new Error('Can not use xOffset \'center\' with placement \'left\' or \'right\'. Callout will overlay the target.'));
+    it('Callout with placement \'right\' and xOffset \'center\' should default to \'xOffset\' of 0px', () => {
+      calloutManager.createCallout({
+        id: 'xOffset-right',
+        target: targetEl,
+        placement: 'right',
+        title: 'Callout with xOffset',
+        content: 'Awesome callout!',
+        xOffset: 'center'
+      });
+      //Can not use xOffset 'center' with placement 'left' or 'right'. Callout will overlay the target.
+      PlacementTestUtils.verifyXOffset(targetEl, 'right', 0);
     });
   });
 
@@ -410,30 +410,31 @@ describe('Callout offsets', () => {
       document.body.setAttribute('dir', 'ltr');
     });
 
-    it('Callout with placement \'top\' and yOffset \'center\' should throw an exception', () => {
-      expect(() => {
-        calloutManager.createCallout({
-          id: 'yOffset-top',
-          target: targetEl,
-          placement: 'top',
-          title: 'Callout with yOffset',
-          content: 'Awesome callout!',
-          yOffset: 'center'
-        });
-      }).toThrow(new Error('Can not use yOffset \'center\' with placement \'top\' or \'bottom\'. Callout will overlay the target.'));
+    it('Callout with placement \'top\' and yOffset \'center\' should default to \'yOffset\' of 0px', () => {
+      calloutManager.createCallout({
+        id: 'yOffset-top',
+        target: targetEl,
+        placement: 'top',
+        title: 'Callout with yOffset',
+        content: 'Awesome callout!',
+        yOffset: 'center'
+      });
+      //Can not use yOffset 'center' with placement 'top' or 'bottom'. Callout will overlay the target.
+      PlacementTestUtils.verifyYOffset(targetEl, 'top', 0);
     });
 
-    it('Callout with placement \'bottom\' and yOffset \'center\' should throw an exception', () => {
-      expect(() => {
-        calloutManager.createCallout({
-          id: 'yOffset-bottom',
-          target: targetEl,
-          placement: 'bottom',
-          title: 'Callout with yOffset',
-          content: 'Awesome callout!',
-          yOffset: 'center'
-        });
-      }).toThrow(new Error('Can not use yOffset \'center\' with placement \'top\' or \'bottom\'. Callout will overlay the target.'));
+    it('Callout with placement \'bottom\' and yOffset \'center\' should default to \'yOffset\' of 0px', () => {
+      calloutManager.createCallout({
+        id: 'yOffset-bottom',
+        target: targetEl,
+        placement: 'bottom',
+        title: 'Callout with yOffset',
+        content: 'Awesome callout!',
+        yOffset: 'center'
+      });
+
+      //Can not use yOffset 'center' with placement 'top' or 'bottom'. Callout will overlay the target.
+      PlacementTestUtils.verifyYOffset(targetEl, 'bottom', 0);
     });
 
     it('Vertical center of the callout with placement \'left\' should be aligned with vertical center of the target', () => {


### PR DESCRIPTION
Deprecated `arrowWidth` per #144. Now CalloutPlacementManager uses `.hopscotch-arrow` element to determine arrow width\height depending on callout placement.

In order to deprecate `arrowWidth` config I had to fix width and height of `.hopscotch-bubble-arrow-container` in core.less. Both were set to `@arrowWidth*2`. But in fact for callouts with placement "top" or "bottom" arrow width is 34px (`@arrowWidth * 2`) and height is 17px (`@arrowWidth`). And for callouts with placement "left" or "right" arrow width is 17px (`@arrowWidth`) and height is 34px (`@arrowWidth * 2`).

Now that arrow element has correct dimensions, it's easy for calloutPlacementManager to grab element height and width and use it in placement calculations rather than relying on config.

Last, but not least, I've added unit tests for `xOffset` and `yOffset` testing each for rtl and non rtl callouts. This brings up current code coverage to 75%.