### PR TITLE
arrowOffset config option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -187,7 +187,7 @@ module.exports = function (grunt) {
         options: {
           outfile: '<%=paths.build%>/test/SpecRunner.html',
           keepRunner: true,
-          specs: ['<%=paths.build%>/test/*.spec.js'],
+          specs: ['<%=paths.build%>/test/specs.js'],
           helpers: ['<%=paths.build%>/test/es/helpers/fixtureSetup.js'],
           styles: ['<%=paths.build%>/css/hopscotch.css']
         }
@@ -197,7 +197,7 @@ module.exports = function (grunt) {
         options: {
           outfile: '<%=paths.build%>/test/SpecRunner.html',
           keepRunner: true,
-          specs: ['<%=paths.build%>/test/*.spec.js'],
+          specs: ['<%=paths.build%>/test/specs.js'],
           helpers: ['<%=paths.build%>/test/es/helpers/fixtureSetup.js'],
           styles: ['<%=paths.build%>/css/hopscotch.css'],
           template: require('grunt-template-jasmine-istanbul'),
@@ -296,12 +296,11 @@ module.exports = function (grunt) {
       },
       test: {
         files: {
-          '<%=paths.build%>/test/placement.spec.js': [
+          '<%=paths.build%>/test/specs.js': [
+            '<%=paths.build%>/test/es/specs/arrowOffset.spec.js',
             '<%=paths.build%>/test/es/specs/placement.spec.js',
+            '<%=paths.build%>/test/es/specs/target.spec.js',
             '<%=paths.build%>/test/es/helpers/placement.js'
-          ],
-          '<%=paths.build%>/test/target.spec.js': [
-            '<%=paths.build%>/test/es/specs/target.spec.js'
           ]
         }
       }

--- a/src/es/hopscotch.js
+++ b/src/es/hopscotch.js
@@ -33,7 +33,7 @@ import * as Utils from './modules/utils.js';
     showNextButton: true,
     width: 280,
     padding: 15,
-    arrowWidth: 20,
+    arrowOffset: 15,
     skipIfNoElement: true,
     isRtl: false,
     cookieName: 'hopscotch.tour.state',

--- a/src/es/managers/PlacementManager.js
+++ b/src/es/managers/PlacementManager.js
@@ -9,30 +9,39 @@ import * as Utils from '../modules/utils.js';
 /* PRIVATE FUNCTIONS AND VARIABLES FOR THIS MODULE */
 
 function setArrowPositionVertical(arrowEl, calloutEl, horizontalProp, arrowOffset) {
-  arrowEl.style.top = '';
   if (arrowOffset == 'center') {
-    arrowEl.style[horizontalProp] = Math.floor((calloutEl.offsetWidth / 2) - arrowEl.offsetWidth / 2) + 'px';
+    //reset to baseline, so we can accurately calculate border width
+    arrowEl.style[horizontalProp] = '0px';
+
+    let calloutElBox = calloutEl.getBoundingClientRect();
+    let arrowElBox = arrowEl.getBoundingClientRect();
+    let calloutBorderWidth = Math.abs(arrowElBox[horizontalProp] - calloutElBox[horizontalProp]);
+    arrowEl.style[horizontalProp] = Math.floor((calloutEl.offsetWidth / 2) - (arrowEl.offsetWidth / 2) - calloutBorderWidth) + 'px';
   } else {
     arrowOffset = Utils.getPixelValue(arrowOffset);
-    if (arrowOffset) {
-      arrowEl.style[horizontalProp] = arrowOffset + 'px';
+    if (isNaN(arrowOffset)) {
+      arrowEl.style[horizontalProp] = '0px';
     } else {
-      arrowEl.style[horizontalProp] = '';
+      arrowEl.style[horizontalProp] = arrowOffset + 'px';
     }
   }
 }
 
 function setArrowPositionHorizontal(arrowEl, calloutEl, horizontalProp, arrowOffset) {
-  arrowEl.style[horizontalProp] = '';
-
   if (arrowOffset == 'center') {
-    arrowEl.style.top = Math.floor((calloutEl.offsetHeight / 2) - arrowEl.offsetHeight / 2) + 'px';
+    //reset to baseline, so we can accurately calculate border width
+    arrowEl.style.top = '0px';
+
+    let calloutElBox = calloutEl.getBoundingClientRect();
+    let arrowElBox = arrowEl.getBoundingClientRect();
+    let calloutBorderWidth = Math.abs(arrowElBox.top - calloutElBox.top);
+    arrowEl.style.top = Math.floor((calloutEl.offsetHeight / 2) - (arrowEl.offsetHeight / 2) - calloutBorderWidth) + 'px';
   } else {
     arrowOffset = Utils.getPixelValue(arrowOffset);
-    if (arrowOffset) {
-      arrowEl.style.top = arrowOffset + 'px';
+    if (isNaN(arrowOffset)) {
+      arrowEl.style[horizontalProp] = '0px';
     } else {
-      arrowEl.style[horizontalProp] = '';
+      arrowEl.style.top = arrowOffset + 'px';
     }
   }
 }
@@ -130,7 +139,6 @@ function positionArrow(callout, placementStrategy) {
   placementStrategy.setArrowPosition(arrowEl, callout.el, horizontalProp, arrowOffset);
 }
 
-
 /**
  * This function sets callout's top and left coordinates as well as it's position (fixed vs absolute)
  * Top and left coordinates are calculated based on target element's position, page scroll as well
@@ -175,7 +183,7 @@ function positionCallout(callout, placementStrategy) {
     if (placement === 'left' || placement === 'right') {
       Utils.logError('Can not use xOffset \'center\' with placement \'left\' or \'right\'. Callout will overlay the target.');
     } else {
-      calloutPosition.left = (targetElBox.left + targetEl.offsetWidth / 2) - (calloutElBox.width / 2);
+      calloutPosition.left = Math.floor(targetElBox.left + targetEl.offsetWidth / 2) - Math.floor(calloutElBox.width / 2);
     }
   }
   else {
@@ -187,7 +195,7 @@ function positionCallout(callout, placementStrategy) {
     if (placement === 'top' || placement === 'bottom') {
       Utils.logError('Can not use yOffset \'center\' with placement \'top\' or \'bottom\'. Callout will overlay the target.');
     } else {
-      calloutPosition.top = (targetElBox.top + targetEl.offsetHeight / 2) - (calloutElBox.height / 2);
+      calloutPosition.top = Math.floor(targetElBox.top + targetEl.offsetHeight / 2) - Math.floor(calloutElBox.height / 2);
     }
   }
   else {

--- a/src/es/modules/config.js
+++ b/src/es/modules/config.js
@@ -4,7 +4,7 @@ export default class Config {
     this.configHash = configHash;
   }
   get(name) {
-    if(this.configHash && this.configHash[name]) {
+    if(this.configHash && typeof this.configHash[name] !== 'undefined') {
       return this.configHash[name];
     }
     if(this.parent) {

--- a/src/less/core.less
+++ b/src/less/core.less
@@ -132,7 +132,6 @@ div.hopscotch-bubble {
 
     &.up {
       top: @arrowOffset;
-      left: @bubbleCornerRadius;
       width: @arrowWidth * 2;
       height: @arrowWidth;
 
@@ -152,7 +151,6 @@ div.hopscotch-bubble {
     }
     &.down {
       bottom: @arrowOffset;
-      left: @bubbleCornerRadius;
       width: @arrowWidth * 2;
       height: @arrowWidth;
 
@@ -171,7 +169,7 @@ div.hopscotch-bubble {
       }
     }
     &.left {
-      top: @bubbleCornerRadius;
+      top: 0;
       left: @arrowOffset;
       width: @arrowWidth;
       height: @arrowWidth * 2;
@@ -192,7 +190,7 @@ div.hopscotch-bubble {
       }
     }
     &.right {
-      top: @bubbleCornerRadius;
+      top: 0;
       right: @arrowOffset;
       width: @arrowWidth;
       height: @arrowWidth * 2;

--- a/test/es/helpers/placement.js
+++ b/test/es/helpers/placement.js
@@ -1,22 +1,10 @@
-function getElementOffset(element) {
-  let top = 0,
-    left = 0,
-    width = element.getBoundingClientRect().width,
-    height = element.getBoundingClientRect().height;
-
-  do {
-    top += element.offsetTop || 0;
-    left += element.offsetLeft || 0;
-    element = element.offsetParent;
-  } while (element);
-
-  return {
-    top: top,
-    left: left,
-    bottom: top + height,
-    right: left + width
-  };
-};
+const OFFSET_CENTER = 'center';
+const PLACEMENT_TOP = 'top';
+const PLACEMENT_BOTTOM = 'bottom';
+const PLACEMENT_LEFT = 'left';
+const PLACEMENT_RIGHT = 'right';
+const QUERY_SELECTOR_CALLOUT = '.hopscotch-bubble';
+const QUERY_SELECTOR_ARROW = '.hopscotch-bubble-arrow-container';
 
 function isPlacedOnTop(calloutPos, arrowEl, targetPos) {
   // placement: top
@@ -67,23 +55,23 @@ function isPlacedOnRight(calloutPos, arrowEl, targetPos) {
 }
 
 function verifyCalloutPlacement(target, expectedPlacement) {
-  let callout = document.querySelector('.hopscotch-bubble');
-  let arrow = document.querySelector('.hopscotch-arrow');
+  let callout = document.querySelector(QUERY_SELECTOR_CALLOUT);
+  let arrow = document.querySelector(QUERY_SELECTOR_ARROW);
   let actualPlacement = 'unknown';
 
   if (callout && arrow) {
 
-    let calloutPos = getElementOffset(callout);
-    let targetPos = getElementOffset(target);
+    let calloutPos = callout.getBoundingClientRect();
+    let targetPos = target.getBoundingClientRect();
 
     if (isPlacedOnTop(calloutPos, arrow, targetPos)) {
-      actualPlacement = 'top';
+      actualPlacement = PLACEMENT_TOP;
     } else if (isPlacedOnBottom(calloutPos, arrow, targetPos)) {
-      actualPlacement = 'bottom';
+      actualPlacement = PLACEMENT_BOTTOM;
     } else if (isPlacedOnLeft(calloutPos, arrow, targetPos)) {
-      actualPlacement = 'left';
+      actualPlacement = PLACEMENT_LEFT;
     } else if (isPlacedOnRight(calloutPos, arrow, targetPos)) {
-      actualPlacement = 'right';
+      actualPlacement = PLACEMENT_RIGHT;
     }
 
     expect('placement:' + actualPlacement).toEqual('placement:' + expectedPlacement);
@@ -93,16 +81,16 @@ function verifyCalloutPlacement(target, expectedPlacement) {
 }
 
 function verifyCalloutIsShown() {
-  let hsCallout = document.querySelector('.hopscotch-bubble'),
-    hsArrow = document.querySelector('.hopscotch-arrow');
+  let hsCallout = document.querySelector(QUERY_SELECTOR_CALLOUT),
+    hsArrow = document.querySelector(QUERY_SELECTOR_ARROW);
 
   expect(hsCallout).toBeDefined();
   expect(hsArrow).toBeDefined();
 }
 
 function verifyCalloutIsNotShown() {
-  let hsCallout = document.querySelector('.hopscotch-bubble'),
-    hsArrow = document.querySelector('.hopscotch-arrow');
+  let hsCallout = document.querySelector(QUERY_SELECTOR_CALLOUT),
+    hsArrow = document.querySelector(QUERY_SELECTOR_ARROW);
 
   expect(hsCallout).not.toBeDefined();
   expect(hsArrow).not.toBeDefined();
@@ -135,44 +123,83 @@ function resetPageScroll() {
 }
 
 /**
+ * Verifies that elements are centered vertically
+ * @private
+ */
+function verifyHorizontalCentersAligned(el1, el2) {
+  let el1Box = el1.getBoundingClientRect();
+  let el2Box = el2.getBoundingClientRect();
+  let el1Center = Math.floor(el1Box.left + (el1.offsetWidth / 2));
+  let el2Center = Math.floor(el2Box.left + (el2.offsetWidth / 2));
+  expect(el1Center).toEqual(el2Center);
+}
+
+/**
+ * Verifies that elements are centered vertically
+ * @private
+ */
+function verifyVerticalCentersAligned(el1, el2) {
+  let el1Box = el1.getBoundingClientRect();
+  let el2Box = el2.getBoundingClientRect();
+  let el1Center = Math.floor(el1Box.top + (el1.offsetHeight / 2));
+  let el2Center = Math.floor(el2Box.top + (el2.offsetHeight / 2));
+  expect(el1Center).toEqual(el2Center);
+}
+
+/**
+ * Verifies that left edge of the el1 has expected offset from the left edge of the el2
+ * In RTL mode this function will compare positions of the right side of the elements
+ * @private
+ */
+function verifyHorizontalOffset(el1, el2, expectedOffset, isRTL) {
+  let el1Box = el1.getBoundingClientRect();
+  let el2Box = el2.getBoundingClientRect();
+  if (isRTL) {
+    expect(el1Box.right - el2Box.right).toEqual(expectedOffset);
+  } else {
+    expect(el1Box.left - el2Box.left).toEqual(expectedOffset);
+  }
+}
+
+/**
+ * Verifies that offset between top positions of both elements equals to expected offset
+ * @private
+ */
+function verifyVerticalOffset(el1, el2, expectedOffset) {
+  let el1Box = el1.getBoundingClientRect();
+  let el2Box = el2.getBoundingClientRect();
+  expect(el1Box.top - el2Box.top).toEqual(expectedOffset);
+}
+
+/**
  * Checks that callout is horizontally offset from target by an expected offset 
  */
 function verifyXOffset(target, placement, expectedOffset) {
-  let callout = document.querySelector('.hopscotch-bubble');
-  let calloutArrow = document.querySelector('.hopscotch-arrow');
+  let callout = document.querySelector(QUERY_SELECTOR_CALLOUT);
+  let arrow = document.querySelector(QUERY_SELECTOR_ARROW);
   let calloutElBox = callout.getBoundingClientRect();
   let targetElBox = target.getBoundingClientRect();
   let isRtl = document.body.getAttribute('dir') === 'rtl';
-  let prop = isRtl ? 'right' : 'left';
   let actualOffset;
 
   //check that offsets are correct for a given placement
-  if (placement === 'top' || placement === 'bottom') {
-    //make sure callout is where it's supposed to be
-    verifyCalloutPlacement(target, placement);
-
-    if (expectedOffset === 'center') {
-      let calloutCenter = calloutElBox.left + (calloutElBox.width / 2);
-      let targetCenter = targetElBox.left + (targetElBox.width / 2);
-      actualOffset = (calloutCenter === targetCenter) ? 'center' : 'not centered';
+  if (placement === PLACEMENT_TOP || placement === PLACEMENT_BOTTOM) {
+    if (expectedOffset === OFFSET_CENTER) {
+      return verifyHorizontalCentersAligned(callout, target);
     } else {
-      //By default left side of the callout placed on top of the target element is
-      //aligned with the left side of the target element
-      //So when xOffset is applied, left side of the callout element is shifted to the
-      //right or the left of the target element's left side
-      actualOffset = calloutElBox[prop] - targetElBox[prop];
+      return verifyHorizontalOffset(callout, target, expectedOffset, isRtl);
     }
-  } else if (placement === 'left') {
+  } else if (placement === PLACEMENT_LEFT) {
     if (isRtl) {
-      actualOffset = (calloutElBox.left - calloutArrow.offsetWidth) - targetElBox.right;
+      actualOffset = (calloutElBox.left - arrow.offsetWidth) - targetElBox.right;
     } else {
-      actualOffset = (calloutElBox.right + calloutArrow.offsetWidth) - targetElBox.left;
+      actualOffset = (calloutElBox.right + arrow.offsetWidth) - targetElBox.left;
     }
-  } else if (placement === 'right') {
+  } else if (placement === PLACEMENT_RIGHT) {
     if (isRtl) {
-      actualOffset = (calloutElBox.right + calloutArrow.offsetWidth) - targetElBox.left;
+      actualOffset = (calloutElBox.right + arrow.offsetWidth) - targetElBox.left;
     } else {
-      actualOffset = (calloutElBox.left - calloutArrow.offsetWidth) - targetElBox.right;
+      actualOffset = (calloutElBox.left - arrow.offsetWidth) - targetElBox.right;
     }
   }
 
@@ -183,28 +210,47 @@ function verifyXOffset(target, placement, expectedOffset) {
  * Checks that callout is vertically offset from target by an expected offset 
  */
 function verifyYOffset(target, placement, expectedOffset) {
-  let callout = document.querySelector('.hopscotch-bubble');
-  let calloutArrow = document.querySelector('.hopscotch-arrow');
+  let callout = document.querySelector(QUERY_SELECTOR_CALLOUT);
+  let arrow = document.querySelector(QUERY_SELECTOR_ARROW);
   let calloutElBox = callout.getBoundingClientRect();
   let targetElBox = target.getBoundingClientRect();
   let actualOffset;
 
   //check that offsets are correct for a given placement
-  if (placement === 'top') {
-    actualOffset = (calloutElBox.bottom + calloutArrow.offsetHeight) - targetElBox.top;
-  } else if (placement === 'bottom') {
-    actualOffset = (calloutElBox.top - calloutArrow.offsetHeight) - targetElBox.bottom;
-  } else if (placement === 'left' || placement === 'right') {
-    if (expectedOffset === 'center') {
-      let calloutCenter = Math.ceil(calloutElBox.top + (calloutElBox.height / 2));
-      let targetCenter = Math.ceil(targetElBox.top + (targetElBox.height / 2));
-      actualOffset = (calloutCenter === targetCenter) ? 'center' : 'not centered';
+  if (placement === PLACEMENT_TOP) {
+    actualOffset = (calloutElBox.bottom + arrow.offsetHeight) - targetElBox.top;
+  } else if (placement === PLACEMENT_BOTTOM) {
+    actualOffset = (calloutElBox.top - arrow.offsetHeight) - targetElBox.bottom;
+  } else if (placement === PLACEMENT_LEFT || placement === PLACEMENT_RIGHT) {
+    if (expectedOffset === OFFSET_CENTER) {
+      return verifyVerticalCentersAligned(callout, target);
     } else {
       actualOffset = calloutElBox.top - targetElBox.top;
     }
   }
-
   expect(actualOffset).toEqual(expectedOffset);
+}
+
+/**
+ * Checks that arrow has expected offset relative to the callout 
+ */
+function verifyArrowOffset(placement, expectedOffset, isRTL) {
+  let callout = document.querySelector(QUERY_SELECTOR_CALLOUT + ' .hopscotch-bubble-container');
+  let arrow = document.querySelector(QUERY_SELECTOR_ARROW);
+
+  if (expectedOffset === OFFSET_CENTER) {
+    if (placement === PLACEMENT_TOP || placement === PLACEMENT_BOTTOM) {
+      return verifyHorizontalCentersAligned(callout, arrow);
+    } else {
+      return verifyVerticalCentersAligned(callout, arrow);
+    }
+  } else {
+    if (placement === PLACEMENT_TOP || placement === PLACEMENT_BOTTOM) {
+      verifyHorizontalOffset(arrow, callout, expectedOffset, isRTL);
+    } else {
+      verifyVerticalOffset(arrow, callout, expectedOffset);
+    }
+  }
 }
 
 let PlacementTestUtils = {
@@ -214,7 +260,8 @@ let PlacementTestUtils = {
   ensurePageScroll,
   resetPageScroll,
   verifyXOffset,
-  verifyYOffset
+  verifyYOffset,
+  verifyArrowOffset
 };
 
 export default PlacementTestUtils;

--- a/test/es/specs/arrowOffset.spec.js
+++ b/test/es/specs/arrowOffset.spec.js
@@ -1,0 +1,321 @@
+import PlacementTestUtils from '../helpers/placement.js';
+
+describe('Arrow offset', () => {
+  let calloutManager = hopscotch.getCalloutManager();
+  let specGroups = [{
+    groupName: 'Placement "top"',
+    specs: [
+      {
+        message: 'Callout with arrowOffset "center" should align center of the arrow with the center of the callout',
+        config: {
+          id: 'arrow-offset-callout',
+          target: '#yogurt',
+          placement: 'top',
+          title: 'Placement "top"',
+          content: 'Callout with arrow offset "center"',
+          arrowOffset: 'center'
+        },
+        expectedOffset: 'center'
+      }, {
+        message: 'Callout with arrowOffset "40px" should push arrow 40px to the right from the callout\'s left edge',
+        config: {
+          id: 'arrow-offset-callout',
+          target: '#yogurt',
+          placement: 'top',
+          title: 'Placement "top"',
+          content: 'Callout with arrow offset "40px"',
+          arrowOffset: '40px'
+        },
+        expectedOffset: 40
+      }, {
+        message: 'Callout with arrowOffset "0px" should align left edge of the arrow with the left edge of the callout',
+        config: {
+          id: 'arrow-offset-callout',
+          target: '#yogurt',
+          placement: 'top',
+          title: 'Placement "top"',
+          content: 'Callout with arrow offset "0px"',
+          arrowOffset: '0px'
+        },
+        expectedOffset: 0
+      }, {
+        message: 'Callout with arrowOffset 0 should align left edge of the arrow with the left edge of the callout',
+        config: {
+          id: 'arrow-offset-callout',
+          target: '#yogurt',
+          placement: 'top',
+          title: 'Placement "top"',
+          content: 'Callout with arrow offset 0',
+          arrowOffset: 0
+        },
+        expectedOffset: 0
+      }, {
+        message: 'Rtl callout with arrowOffset "center" should align center of the arrow with the center of the callout',
+        config: {
+          id: 'arrow-offset-callout',
+          target: '#yogurt',
+          placement: 'top',
+          title: 'Placement "top"',
+          content: 'Rtl callout with arrow offset "center"',
+          arrowOffset: 'center',
+          isRtl: true
+        },
+        expectedOffset: 'center'
+      }, {
+        message: 'Rtl callout with arrowOffset "40px" should push arrow 40px to the left from the callout\'s right edge',
+        config: {
+          id: 'arrow-offset-callout',
+          target: '#yogurt',
+          placement: 'top',
+          title: 'Placement "top"',
+          content: 'Rtl callout with arrow offset "40px"',
+          arrowOffset: '40px',
+          isRtl: true
+        },
+        expectedOffset: -40
+      }, {
+        message: 'Rtl callout with arrowOffset "0px" should align right edge of the arrow with the right edge of the callout',
+        config: {
+          id: 'arrow-offset-callout',
+          target: '#yogurt',
+          placement: 'top',
+          title: 'Placement "top"',
+          content: 'Rtl callout with arrow offset "0px"',
+          arrowOffset: '0px',
+          isRtl: true
+        },
+        expectedOffset: 0
+      }, {
+        message: 'Rtl callout with arrowOffset 0 should align right edge of the arrow with the right edge of the callout',
+        config: {
+          id: 'arrow-offset-callout',
+          target: '#yogurt',
+          placement: 'top',
+          title: 'Placement "top"',
+          content: 'Rtl callout with arrow offset 0',
+          arrowOffset: 0,
+          isRtl: true
+        },
+        expectedOffset: 0
+      },
+
+    ]
+  }, {
+      groupName: 'Placement "bottom"',
+      specs: [
+        {
+          message: 'Callout with arrowOffset "center" should align center of the arrow with the center of the callout',
+          config: {
+            id: 'arrow-offset-callout',
+            target: '#yogurt',
+            placement: 'bottom',
+            title: 'Placement "bottom"',
+            content: 'Callout with arrow offset "center"',
+            arrowOffset: 'center'
+          },
+          expectedOffset: 'center'
+        }, {
+          message: 'Callout with arrowOffset "40px" should push arrow 40px to the right from the callout\'s left edge',
+          config: {
+            id: 'arrow-offset-callout',
+            target: '#yogurt',
+            placement: 'bottom',
+            title: 'Placement "bottom"',
+            content: 'Callout with arrow offset "40px"',
+            arrowOffset: '40px'
+          },
+          expectedOffset: 40
+        }, {
+          message: 'Callout with arrowOffset "0px" should align left edge of the arrow with the left edge of the callout',
+          config: {
+            id: 'arrow-offset-callout',
+            target: '#yogurt',
+            placement: 'bottom',
+            title: 'Placement "bottom"',
+            content: 'Callout with arrow offset "0px"',
+            arrowOffset: '0px'
+          },
+          expectedOffset: 0
+        }, {
+          message: 'Callout with arrowOffset 0 should align left edge of the arrow with the left edge of the callout',
+          config: {
+            id: 'arrow-offset-callout',
+            target: '#yogurt',
+            placement: 'bottom',
+            title: 'Placement "bottom"',
+            content: 'Callout with arrow offset 0',
+            arrowOffset: 0
+          },
+          expectedOffset: 0
+        }, {
+          message: 'Rtl callout with arrowOffset "center" should align center of the arrow with the center of the callout',
+          config: {
+            id: 'arrow-offset-callout',
+            target: '#yogurt',
+            placement: 'bottom',
+            title: 'Placement "bottom"',
+            content: 'Rtl callout with arrow offset "center"',
+            arrowOffset: 'center',
+            isRtl: true
+          },
+          expectedOffset: 'center'
+        }, {
+          message: 'Rtl callout with arrowOffset "40px" should push arrow 40px to the left from the callout\'s right edge',
+          config: {
+            id: 'arrow-offset-callout',
+            target: '#yogurt',
+            placement: 'bottom',
+            title: 'Placement "bottom"',
+            content: 'Rtl callout with arrow offset "40px"',
+            arrowOffset: '40px',
+            isRtl: true
+          },
+          expectedOffset: -40
+        }, {
+          message: 'Rtl callout with arrowOffset "0px" should align right edge of the arrow with the right edge of the callout',
+          config: {
+            id: 'arrow-offset-callout',
+            target: '#yogurt',
+            placement: 'bottom',
+            title: 'Placement "bottom"',
+            content: 'Rtl callout with arrow offset "0px"',
+            arrowOffset: '0px',
+            isRtl: true
+          },
+          expectedOffset: 0
+        }, {
+          message: 'Rtl callout with arrowOffset 0 should align right edge of the arrow with the right edge of the callout',
+          config: {
+            id: 'arrow-offset-callout',
+            target: '#yogurt',
+            placement: 'bottom',
+            title: 'Placement "bottom"',
+            content: 'Rtl callout with arrow offset 0',
+            arrowOffset: 0,
+            isRtl: true
+          },
+          expectedOffset: 0
+        }]
+    },
+    {
+      groupName: 'Placement "left"',
+      specs: [
+        {
+          message: 'Callout with arrowOffset "center" should align center of the arrow with the center of the callout',
+          config: {
+            id: 'arrow-offset-callout',
+            target: '#yogurt',
+            placement: 'left',
+            title: 'Placement "left"',
+            content: 'Callout with arrow offset "center"',
+            arrowOffset: 'center'
+          },
+          expectedOffset: 'center'
+        }, {
+          message: 'Callout with arrowOffset "40px" should push arrow 40px down from callout\'s top',
+          config: {
+            id: 'arrow-offset-callout',
+            target: '#yogurt',
+            placement: 'left',
+            title: 'Placement "left"',
+            content: 'Callout with arrow offset "40px"',
+            arrowOffset: '40px'
+          },
+          expectedOffset: 40
+        }, {
+          message: 'Callout with arrowOffset "0px" should align top of the arrow with the top of the callout',
+          config: {
+            id: 'arrow-offset-callout',
+            target: '#yogurt',
+            placement: 'left',
+            title: 'Placement "left"',
+            content: 'Callout with arrow offset "0px"',
+            arrowOffset: '0px'
+          },
+          expectedOffset: 0
+        }, {
+          message: 'Callout with arrowOffset 0 should align top of the arrow with the top of the callout',
+          config: {
+            id: 'arrow-offset-callout',
+            target: '#yogurt',
+            placement: 'left',
+            title: 'Placement "left"',
+            content: 'Callout with arrow offset 0',
+            arrowOffset: 0
+          },
+          expectedOffset: 0
+        }
+      ]
+    },
+    {
+      groupName: 'Placement "right"',
+      specs: [
+        {
+          message: 'Callout with arrowOffset "center" should align center of the arrow with the center of the callout',
+          config: {
+            id: 'arrow-offset-callout',
+            target: '#yogurt',
+            placement: 'right',
+            title: 'Placement "right"',
+            content: 'Callout with arrow offset "center"',
+            arrowOffset: 'center'
+          },
+          expectedOffset: 'center'
+        }, {
+          message: 'Callout with arrowOffset "40px" should push arrow 40px down from callout\'s top',
+          config: {
+            id: 'arrow-offset-callout',
+            target: '#yogurt',
+            placement: 'right',
+            title: 'Placement "right"',
+            content: 'Callout with arrow offset "40px"',
+            arrowOffset: '40px'
+          },
+          expectedOffset: 40
+        }, {
+          message: 'Callout with arrowOffset "0px" should align top of the arrow with the top of the callout',
+          config: {
+            id: 'arrow-offset-callout',
+            target: '#yogurt',
+            placement: 'right',
+            title: 'Placement "right"',
+            content: 'Callout with arrow offset "0px"',
+            arrowOffset: '0px'
+          },
+          expectedOffset: 0
+        }, {
+          message: 'Callout with arrowOffset 0 should align top of the arrow with the top of the callout',
+          config: {
+            id: 'arrow-offset-callout',
+            target: '#yogurt',
+            placement: 'right',
+            title: 'Placement "right"',
+            content: 'Callout with arrow offset 0',
+            arrowOffset: 0
+          },
+          expectedOffset: 0
+        }
+      ]
+    }
+  ];
+
+  specGroups.forEach((specGroup) => {
+    describe(specGroup.groupName, () => {
+      specGroup.specs.forEach((spec) => {
+        it(spec.message, () => {
+          if (spec.config.isRtl) {
+            document.body.setAttribute('dir', 'rtl');
+          }
+          //create a callout
+          calloutManager.createCallout(spec.config);
+          //verify arrow placement
+          PlacementTestUtils.verifyArrowOffset(spec.config.placement, spec.expectedOffset, spec.config.isRtl);
+          //remove the callout
+          calloutManager.removeAllCallouts();
+          //reset text direction
+          document.body.setAttribute('dir', 'ltr');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adding unit tests for `arrowOffset` config option.
`arrowOffset :  'center'` did not correctly account for the border width of the callout. This PR fixes that.