### PR TITLE
#219 Unit tests for `target` and `getTarget` config options

### DIFF
--- a/src/es/managers/PlacementManager.js
+++ b/src/es/managers/PlacementManager.js
@@ -46,7 +46,7 @@ function setArrowPositionVertical(arrowEl, calloutEl, horizontalProp, arrowOffse
     let calloutElBox = calloutEl.getBoundingClientRect();
     let arrowElBox = arrowEl.getBoundingClientRect();
     let calloutBorderWidth = Math.abs(arrowElBox[horizontalProp] - calloutElBox[horizontalProp]);
-    arrowEl.style[horizontalProp] = Math.floor((calloutEl.offsetWidth / 2) - (arrowEl.offsetWidth / 2) - calloutBorderWidth) + 'px';
+    arrowEl.style[horizontalProp] = Math.floor(calloutEl.offsetWidth / 2) - Math.floor(arrowEl.offsetWidth / 2) - calloutBorderWidth + 'px';
   } else {
     //getPixelValue will return 0 if value is not a number
     arrowEl.style[horizontalProp] = Utils.getPixelValue(arrowOffset) + 'px';
@@ -61,7 +61,7 @@ function setArrowPositionHorizontal(arrowEl, calloutEl, horizontalProp, arrowOff
     let calloutElBox = calloutEl.getBoundingClientRect();
     let arrowElBox = arrowEl.getBoundingClientRect();
     let calloutBorderWidth = Math.abs(arrowElBox.top - calloutElBox.top);
-    arrowEl.style.top = Math.floor((calloutEl.offsetHeight / 2) - (arrowEl.offsetHeight / 2) - calloutBorderWidth) + 'px';
+    arrowEl.style.top = Math.floor(calloutEl.offsetHeight / 2) - Math.floor(arrowEl.offsetHeight / 2) - calloutBorderWidth + 'px';
   } else {
     arrowEl.style.top = Utils.getPixelValue(arrowOffset) + 'px';
   }
@@ -180,8 +180,8 @@ function positionCallout(callout, placementStrategy) {
   }
 
   let targetEl = getTarget(callout.config.get('target'));
-  if (!targetEl) {
-    throw new Error('Must specify an existing target element via \'target\' option.');
+  if (!Utils.isDOMElement(targetEl)) {
+    throw new Error('Target element is not a DOM object. Please provide valid target DOM element or query selector via \'target\' option.');
   }
 
   let isTargetFixed = isFixedElement(targetEl);
@@ -204,7 +204,7 @@ function positionCallout(callout, placementStrategy) {
     if (placement === 'left' || placement === 'right') {
       Utils.logError('Can not use xOffset \'center\' with placement \'left\' or \'right\'. Callout will overlay the target.');
     } else {
-      calloutPosition.left = Math.floor(targetElBox.left + targetEl.offsetWidth / 2) - Math.floor(calloutElBox.width / 2);
+      calloutPosition.left = targetElBox.left + Math.floor(targetEl.offsetWidth / 2) - Math.floor(calloutElBox.width / 2);
     }
   }
   else {
@@ -216,7 +216,7 @@ function positionCallout(callout, placementStrategy) {
     if (placement === 'top' || placement === 'bottom') {
       Utils.logError('Can not use yOffset \'center\' with placement \'top\' or \'bottom\'. Callout will overlay the target.');
     } else {
-      calloutPosition.top = Math.floor(targetElBox.top + targetEl.offsetHeight / 2) - Math.floor(calloutElBox.height / 2);
+      calloutPosition.top = targetElBox.top + Math.floor(targetEl.offsetHeight / 2) - Math.floor(calloutElBox.height / 2);
     }
   }
   else {
@@ -259,7 +259,7 @@ function getScrollPosition() {
  * @private
  */
 function isFixedElement(el) {
-  if (!el.style) {
+  if (!el || !el.style) {
     return false;
   } else if (el.style.position === 'fixed') {
     return true;

--- a/src/es/modules/utils.js
+++ b/src/es/modules/utils.js
@@ -152,3 +152,22 @@ export function extend(obj1, obj2) {
   }
   return obj1;
 }
+
+/**
+ * Determines if el parameter of this function conforms for the DOM
+ * API required by hopscotch
+ */
+export function isDOMElement(el) {
+  if (!el || typeof el.getBoundingClientRect !== 'function') {
+    return false;
+  }
+  let elBox = el.getBoundingClientRect();
+
+  return typeof el.style === 'object' &&
+    typeof elBox.right === 'number' &&
+    typeof elBox.left === 'number' &&
+    typeof elBox.top === 'number' &&
+    typeof elBox.bottom === 'number' &&
+    typeof elBox.height === 'number' &&
+    typeof elBox.width === 'number';
+}

--- a/test/es/helpers/placement.js
+++ b/test/es/helpers/placement.js
@@ -17,7 +17,7 @@ function isPlacedOnTop(calloutPos, arrowEl, targetPos) {
   //         _______________
   //        |   Target      |
   //        |_______________|
-  return (calloutPos.bottom + arrowEl.offsetHeight) === targetPos.top;
+  return Math.round(calloutPos.bottom + arrowEl.offsetHeight) === Math.round(targetPos.top);
 }
 
 function isPlacedOnBottom(calloutPos, arrowEl, targetPos) {
@@ -31,7 +31,7 @@ function isPlacedOnBottom(calloutPos, arrowEl, targetPos) {
   //        ----------------
   //        |   Callout    |
   //        ----------------
-  return (calloutPos.top - arrowEl.offsetHeight) === targetPos.bottom;
+  return Math.round(calloutPos.top - arrowEl.offsetHeight) === Math.round(targetPos.bottom);
 }
 
 function isPlacedOnLeft(calloutPos, arrowEl, targetPos) {
@@ -41,7 +41,7 @@ function isPlacedOnLeft(calloutPos, arrowEl, targetPos) {
   //        ----------------   ----------------
   //        |   Callout    |>  |   Target     |
   //        ----------------   ----------------
-  return (calloutPos.right + arrowEl.offsetWidth) === targetPos.left;
+  return Math.round(calloutPos.right + arrowEl.offsetWidth) === Math.round(targetPos.left);
 }
 
 function isPlacedOnRight(calloutPos, arrowEl, targetPos) {
@@ -51,7 +51,7 @@ function isPlacedOnRight(calloutPos, arrowEl, targetPos) {
   //        ----------------   ----------------
   //        |   Target     | < |   Callout    |
   //        ----------------   ----------------
-  return (calloutPos.left - arrowEl.offsetWidth) === targetPos.right;
+  return Math.round(calloutPos.left - arrowEl.offsetWidth) === Math.round(targetPos.right);
 }
 
 function verifyCalloutPlacement(target, expectedPlacement) {
@@ -155,9 +155,9 @@ function verifyHorizontalOffset(el1, el2, expectedOffset, isRTL) {
   let el1Box = el1.getBoundingClientRect();
   let el2Box = el2.getBoundingClientRect();
   if (isRTL) {
-    expect(el1Box.right - el2Box.right).toEqual(expectedOffset);
+    expect(Math.floor(el1Box.right - el2Box.right)).toEqual(expectedOffset);
   } else {
-    expect(el1Box.left - el2Box.left).toEqual(expectedOffset);
+    expect(Math.floor(el1Box.left - el2Box.left)).toEqual(expectedOffset);
   }
 }
 
@@ -168,7 +168,7 @@ function verifyHorizontalOffset(el1, el2, expectedOffset, isRTL) {
 function verifyVerticalOffset(el1, el2, expectedOffset) {
   let el1Box = el1.getBoundingClientRect();
   let el2Box = el2.getBoundingClientRect();
-  expect(el1Box.top - el2Box.top).toEqual(expectedOffset);
+  expect(Math.floor(el1Box.top - el2Box.top)).toEqual(expectedOffset);
 }
 
 /**
@@ -202,7 +202,7 @@ function verifyXOffset(target, placement, expectedOffset, isRtl) {
     }
   }
 
-  expect(actualOffset).toEqual(expectedOffset);
+  expect(Math.floor(actualOffset)).toEqual(expectedOffset);
 }
 
 /**
@@ -227,7 +227,7 @@ function verifyYOffset(target, placement, expectedOffset) {
       actualOffset = calloutElBox.top - targetElBox.top;
     }
   }
-  expect(actualOffset).toEqual(expectedOffset);
+  expect(Math.floor(actualOffset)).toEqual(expectedOffset);
 }
 
 /**

--- a/test/es/specs/target.spec.js
+++ b/test/es/specs/target.spec.js
@@ -1,19 +1,242 @@
-describe('Config option "target"', () => {
-  describe('Callout missing target', () => {
-    it('Should throw an exception when standalone callout does not have a valid target', () => {
-      let calloutMgr = hopscotch.getCalloutManager();
-      let calloutID = 'callout-no-target';
-      expect(() => {
-        calloutMgr.createCallout({
-          id: calloutID,
-          target: 'totally-does-not-exist',
-          placement: 'bottom',
-          title: 'This test is fun!',
-          content: 'This is how we test this library!'
-        });
-      }).toThrow(new Error('Must specify an existing target element via \'target\' option.'));
+import PlacementTestUtils from '../helpers/placement.js';
 
-      expect(calloutMgr.getCallout(calloutID)).toBeUndefined();
-    });
-  });
+describe('Config option "target"', () => {
+  let calloutManager = hopscotch.getCalloutManager();
+  let specGroups = [
+    {
+      groupName: 'Valid target',
+      specs: [
+        {
+          message: 'Should use provided DOM element as a target',
+          config: {
+            id: 'standalone-callout',
+            placement: 'top',
+            target: document.querySelector('#yogurt'),
+            title: 'This test is fun!',
+            content: 'This is how we test this library!'
+          },
+          after() {
+            let targetEl = document.querySelector('#yogurt');
+            //verify that callout points at the correct target
+            PlacementTestUtils.verifyCalloutPlacement(targetEl, 'top');
+          }
+        }, {
+          message: 'Should use provided query selector to find target element',
+          config: {
+            id: 'standalone-callout',
+            placement: 'top',
+            target: '#yogurt',
+            title: 'This test is fun!',
+            content: 'This is how we test this library!'
+          },
+          after() {
+            let targetEl = document.querySelector('#yogurt');
+            //verify that callout points at the correct target
+            PlacementTestUtils.verifyCalloutPlacement(targetEl, 'top');
+          }
+        }, {
+          message: 'Should use complex query selector to find target element',
+          config: {
+            id: 'standalone-callout',
+            placement: 'bottom',
+            target: '#shopping-list ul li+li',
+            title: 'This test is fun!',
+            content: 'This is how we test this library!'
+          },
+          after() {
+            let targetEl = document.querySelector('#milk');
+            //verify that callout points at the correct target
+            PlacementTestUtils.verifyCalloutPlacement(targetEl, 'bottom');
+          }
+        }, {
+          message: 'Should pick first target from the array of query selectors',
+          config: {
+            id: 'standalone-callout',
+            placement: 'bottom',
+            target: [-100, 'does not exit', '#milk', '#yogurt'],
+            title: 'This test is fun!',
+            content: 'This is how we test this library!'
+          },
+          after() {
+            let targetEl = document.querySelector('#milk');
+            //verify that callout points at the correct target
+            PlacementTestUtils.verifyCalloutPlacement(targetEl, 'bottom');
+          }
+        }
+      ]
+    }, {
+      groupName: 'Invalid target',
+      specs: [
+        {
+          message: 'Should throw an exception when "target" options is not provided',
+          config: {
+            id: 'standalone-callout',
+            placement: 'bottom',
+            title: 'This test is fun!',
+            content: 'This is how we test this library!'
+          },
+          error: 'Target element is not a DOM object. Please provide valid target DOM element or query selector via \'target\' option.',
+          after() {
+            expect(calloutManager.getCallout('standalone-callout')).toBeUndefined();
+          }
+        }, {
+          message: 'Should throw an exception when target query selector does not match any element',
+          config: {
+            id: 'standalone-callout',
+            target: 'yogurt',
+            placement: 'bottom',
+            title: 'This test is fun!',
+            content: 'This is how we test this library!'
+          },
+          error: 'Target element is not a DOM object. Please provide valid target DOM element or query selector via \'target\' option.',
+          after() {
+            expect(calloutManager.getCallout('standalone-callout')).toBeUndefined();
+          }
+        }, {
+          message: 'Should throw an exception when target is a function',
+          config: {
+            id: 'standalone-callout',
+            target: function () {
+              return document.querySelector('#yogurt');
+            },
+            placement: 'bottom',
+            title: 'This test is fun!',
+            content: 'This is how we test this library!'
+          },
+          error: 'Target element is not a DOM object. Please provide valid target DOM element or query selector via \'target\' option.',
+          after() {
+            expect(calloutManager.getCallout('standalone-callout')).toBeUndefined();
+          }
+        }, {
+          message: 'Should throw an exception when target is an object',
+          config: {
+            id: 'standalone-callout',
+            target: {},
+            placement: 'bottom',
+            title: 'This test is fun!',
+            content: 'This is how we test this library!'
+          },
+          error: 'Target element is not a DOM object. Please provide valid target DOM element or query selector via \'target\' option.',
+          after() {
+            expect(calloutManager.getCallout('standalone-callout')).toBeUndefined();
+          }
+        }, {
+          message: 'Should throw an exception when target is an empty array',
+          config: {
+            id: 'standalone-callout',
+            target: [],
+            placement: 'bottom',
+            title: 'This test is fun!',
+            content: 'This is how we test this library!'
+          },
+          error: 'Target element is not a DOM object. Please provide valid target DOM element or query selector via \'target\' option.',
+          after() {
+            expect(calloutManager.getCallout('standalone-callout')).toBeUndefined();
+          }
+        }, {
+          message: 'Should throw an exception when target is an array that does not contain strings',
+          config: {
+            id: 'standalone-callout',
+            target: [1, 2, 3, 4, 5],
+            placement: 'bottom',
+            title: 'This test is fun!',
+            content: 'This is how we test this library!'
+          },
+          error: 'Target element is not a DOM object. Please provide valid target DOM element or query selector via \'target\' option.',
+          after() {
+            expect(calloutManager.getCallout('standalone-callout')).toBeUndefined();
+          }
+        }, {
+          message: 'Should throw an exception if none of the query selectors withing array match an existing target element',
+          config: {
+            id: 'standalone-callout',
+            target: ['#yogurtland', 'spania', '.rambleBlah'],
+            placement: 'bottom',
+            title: 'This test is fun!',
+            content: 'This is how we test this library!'
+          },
+          error: 'Target element is not a DOM object. Please provide valid target DOM element or query selector via \'target\' option.',
+          after() {
+            expect(calloutManager.getCallout('standalone-callout')).toBeUndefined();
+          }
+        }
+      ]
+    }, {
+      groupName: 'Custom \'getTarget\' function',
+      specs: [
+        {
+          message: 'Should throw an exception getTarget is not a function',
+          config: {
+            id: 'standalone-callout',
+            target: 'doesNotMatter',
+            getTarget: document.querySelector('jeez'),
+            placement: 'bottom',
+            title: 'This test is fun!',
+            content: 'This is how we test this library!',
+          },
+          error: 'Can not find target element because \'getTarget\' is not a function',
+          after() {
+            expect(calloutManager.getCallout('standalone-callout')).toBeUndefined();
+          }
+        }, {
+          message: 'Should throw an exception if getTarget does not return valid DOM element',
+          config: {
+            id: 'standalone-callout',
+            target: 'doesNotMatter',
+            getTarget() {
+              //not returning anything
+            },
+            placement: 'bottom',
+            title: 'This test is fun!',
+            content: 'This is how we test this library!',
+          },
+          error: 'Target element is not a DOM object. Please provide valid target DOM element or query selector via \'target\' option.',
+          after() {
+            expect(calloutManager.getCallout('standalone-callout')).toBeUndefined();
+          }
+        }, {
+          message: 'Should use target returned by "getTarget" function',
+          config: {
+            id: 'standalone-callout',
+            target: '#yogurt',
+            getTarget(target) {
+              return document.querySelector(target);
+            },
+            placement: 'bottom',
+            title: 'This test is fun!',
+            content: 'This is how we test this library!',
+          },
+          after() {
+            PlacementTestUtils.verifyCalloutPlacement(document.querySelector('#yogurt'), 'bottom');
+          }
+        }
+      ]
+    }
+  ];
+
+  specGroups.forEach((specGroup) => {
+    describe(specGroup.groupName, () => {
+      specGroup.specs.forEach((spec) => {
+        it(spec.message, () => {
+          if (spec.before) {
+            spec.before();
+          }
+
+          if (spec.error) {
+            expect(() => {
+              calloutManager.createCallout(spec.config);
+            }).toThrow(new Error(spec.error));
+          } else {
+            calloutManager.createCallout(spec.config);
+          }
+
+          if (spec.after) {
+            spec.after();
+          }
+
+          calloutManager.removeAllCallouts();
+        }); //end "it" for a spec
+      }); //end of specs loop
+    }); //end "describe" for a spec group
+  });//end of specGroups loop
 });


### PR DESCRIPTION
This pull request resolves #219 

 - Adding unit tests for `target` and `getTarget` config options
 - Ran unit tests in Chrome, Safari and Firefox. Had to add Math.floor and Math.round to PlacementManaget and placement test utils since Firefox has values with fractions returned from `getBoundingClientRect`.
