### PR TITLE
Include all test spec files instead of listing them individually in Gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -297,12 +297,8 @@ module.exports = function (grunt) {
       test: {
         files: {
           '<%=paths.build%>/test/specs.js': [
-            '<%=paths.build%>/test/es/specs/arrowOffset.spec.js',
-            '<%=paths.build%>/test/es/specs/placement.spec.js',
-            '<%=paths.build%>/test/es/specs/target.spec.js',
-            '<%=paths.build%>/test/es/specs/xOffset.spec.js',
-            '<%=paths.build%>/test/es/specs/yOffset.spec.js',
-            '<%=paths.build%>/test/es/helpers/placement.js'
+            '<%=paths.build%>/test/es/helpers/placement.js',
+            '<%=paths.build%>/test/es/specs/*.spec.js'
           ]
         }
       }


### PR DESCRIPTION
This change simplifies the process of adding new test spec files. With this change you can simply create a new spec file in test folder, and it will be automatically picked up and added to the overall test suite.