### PR TITLE
Add `hopscotch.resetDefaultOptions` method.

### DIFF
--- a/src/es/hopscotch.js
+++ b/src/es/hopscotch.js
@@ -52,7 +52,7 @@ import * as Utils from './modules/utils.js';
   }.call(tmplClosureOut));
 
   // Hacky code to move templates from old namespace to TemplateManager.
-  for(let tl in tmplClosureOut.templates){
+  for (let tl in tmplClosureOut.templates) {
     TemplateManager.registerTemplate(tl, tmplClosureOut.templates[tl]);
   }
 
@@ -87,12 +87,15 @@ import * as Utils from './modules/utils.js';
     getState() {
     },
     configure(configHash) {
-      if(!configHash) {
+      if (!configHash) {
         return;
       }
-      for(let prop in configHash){
+      for (let prop in configHash) {
         globalConfig.set(prop, configHash[prop]);
       }
+    },
+    resetDefaultOptions() {
+      globalConfig = new Config({}, defaultConfig);
     }
   };
 })));

--- a/test/es/specs/xOffset.spec.js
+++ b/test/es/specs/xOffset.spec.js
@@ -676,6 +676,7 @@ describe('Config option "xOffset"', () => {
       });
       afterEach(() => {
         document.body.setAttribute('dir', 'ltr');
+        hopscotch.resetDefaultOptions();
       });
       specGroup.specs.forEach((spec) => {
         it(spec.message, () => {

--- a/test/es/specs/yOffset.spec.js
+++ b/test/es/specs/yOffset.spec.js
@@ -435,6 +435,11 @@ describe('Config option "yOffset"', () => {
 
   specGroups.forEach((specGroup) => {
     describe(specGroup.groupName, () => {
+      afterEach(() => {
+        //remove the callout
+        calloutManager.removeAllCallouts();
+        hopscotch.resetDefaultOptions();
+      });
       specGroup.specs.forEach((spec) => {
         it(spec.message, () => {
           if (typeof spec.before === 'function') {
@@ -444,8 +449,6 @@ describe('Config option "yOffset"', () => {
           calloutManager.createCallout(spec.config);
           //verify arrow placement
           PlacementTestUtils.verifyYOffset(document.querySelector(spec.config.target), spec.config.placement, spec.expectedOffset);
-          //remove the callout
-          calloutManager.removeAllCallouts();
         }); //end "it" for a spec
       }); //end specs loop
     }); //end "describe" for a spec group 


### PR DESCRIPTION
Adding `hopscotch.resetDefaultOptions`. Updating xOffset and yOffset specs to use it, since they are using `hopscotch.configure`. This allows to wipe the slate clean after each unit test run.

Right now we do not have explicit unit tests for `resetDefaultOptions` and `configure`. We should add comprehensive set of unit tests for these methods as part of #67 