### PR TITLE
Encapsulate the logic of finding target element within the Callout class.

### DIFF
--- a/src/es/managers/PlacementManager.js
+++ b/src/es/managers/PlacementManager.js
@@ -166,24 +166,7 @@ function positionArrow(callout, placementStrategy) {
  * as xOffset and yOffset configuration options 
  */
 function positionCallout(callout, placementStrategy) {
-  //User can configure their own way of finding target element
-  //via hopscotch.configure. For example jQuery
-  // hopscotch.configure({
-  //  getTarget: function(target){
-  //    return jQUery(target);
-  //  }
-  // });
-  //If not specified getTarget defaults to Utils.getTargetEl
-  let getTarget = callout.config.get('getTarget');
-  if (typeof getTarget !== 'function') {
-    throw new Error('Can not find target element because \'getTarget\' is not a function');
-  }
-
-  let targetEl = getTarget(callout.config.get('target'));
-  if (!Utils.isDOMElement(targetEl)) {
-    throw new Error('Target element is not a DOM object. Please provide valid target DOM element or query selector via \'target\' option.');
-  }
-
+  let targetEl = callout.getTargetElement();
   let isTargetFixed = isFixedElement(targetEl);
   let targetElBox = targetEl.getBoundingClientRect();
   let calloutElBox = callout.el.getBoundingClientRect();

--- a/src/es/modules/callout.js
+++ b/src/es/modules/callout.js
@@ -106,6 +106,32 @@ export class Callout {
       }
     };
   }
+  
+  /**
+   * Find the DOM element this callout points to
+   *
+   * @returns {Element} DOM element that is the target of this callout
+   */
+  getTargetElement() {
+    /* User can configure their own way of finding target element via hopscotch.configure. For example jQuery
+     * hopscotch.configure({
+     *  getTarget: function(target){
+     *    return jQUery(target);
+     *  }
+     * });
+     * If not specified getTarget defaults to Utils.getTargetEl
+    */
+    let getTarget = this.config.get('getTarget');
+    if (typeof getTarget !== 'function') {
+      throw new Error('Can not find target element because \'getTarget\' is not a function');
+    }
+
+    let targetEl = getTarget(this.config.get('target'));
+    if (!Utils.isDOMElement(targetEl)) {
+      throw new Error('Target element is not a DOM object. Please provide valid target DOM element or query selector via \'target\' option.');
+    }
+    return targetEl;
+  }
 }
 
 /**


### PR DESCRIPTION
The logic of finding target element will be re-used withing tour workflow, so it does not make sense for it to live in PlacementManager. It is callout's responsibility to know it's target element. Hence I'm encapsulating this logic within the Callout class.