### PR TITLE
#230 Use getBoundingClientRect for all placement calculations

### DIFF
--- a/src/es/managers/PlacementManager.js
+++ b/src/es/managers/PlacementManager.js
@@ -46,7 +46,7 @@ function setArrowPositionVertical(arrowEl, calloutEl, horizontalProp, arrowOffse
     let calloutElBox = calloutEl.getBoundingClientRect();
     let arrowElBox = arrowEl.getBoundingClientRect();
     let calloutBorderWidth = Math.abs(arrowElBox[horizontalProp] - calloutElBox[horizontalProp]);
-    arrowEl.style[horizontalProp] = Math.floor(calloutEl.offsetWidth / 2) - Math.floor(arrowEl.offsetWidth / 2) - calloutBorderWidth + 'px';
+    arrowEl.style[horizontalProp] = Math.floor(calloutElBox.width / 2) - Math.floor(arrowElBox.width / 2) - calloutBorderWidth + 'px';
   } else {
     //getPixelValue will return 0 if value is not a number
     arrowEl.style[horizontalProp] = Utils.getPixelValue(arrowOffset) + 'px';
@@ -61,7 +61,7 @@ function setArrowPositionHorizontal(arrowEl, calloutEl, horizontalProp, arrowOff
     let calloutElBox = calloutEl.getBoundingClientRect();
     let arrowElBox = arrowEl.getBoundingClientRect();
     let calloutBorderWidth = Math.abs(arrowElBox.top - calloutElBox.top);
-    arrowEl.style.top = Math.floor(calloutEl.offsetHeight / 2) - Math.floor(arrowEl.offsetHeight / 2) - calloutBorderWidth + 'px';
+    arrowEl.style.top = Math.floor(calloutElBox.height / 2) - Math.floor(arrowElBox.height / 2) - calloutBorderWidth + 'px';
   } else {
     arrowEl.style.top = Utils.getPixelValue(arrowOffset) + 'px';
   }
@@ -195,7 +195,7 @@ function positionCallout(callout, placementStrategy) {
     if (placement === 'left' || placement === 'right') {
       Utils.logError('Can not use xOffset \'center\' with placement \'left\' or \'right\'. Callout will overlay the target.');
     } else {
-      calloutPosition.left = targetElBox.left + Math.floor(targetEl.offsetWidth / 2) - Math.floor(calloutElBox.width / 2);
+      calloutPosition.left = targetElBox.left + Math.floor(targetElBox.width / 2) - Math.floor(calloutElBox.width / 2);
     }
   }
   else {
@@ -207,7 +207,7 @@ function positionCallout(callout, placementStrategy) {
     if (placement === 'top' || placement === 'bottom') {
       Utils.logError('Can not use yOffset \'center\' with placement \'top\' or \'bottom\'. Callout will overlay the target.');
     } else {
-      calloutPosition.top = targetElBox.top + Math.floor(targetEl.offsetHeight / 2) - Math.floor(calloutElBox.height / 2);
+      calloutPosition.top = targetElBox.top + Math.floor(targetElBox.height / 2) - Math.floor(calloutElBox.height / 2);
     }
   }
   else {

--- a/test/es/helpers/fixtureSetup.js
+++ b/test/es/helpers/fixtureSetup.js
@@ -1,12 +1,16 @@
 function setupFixture() {
   //create an element for shopping list
-  let shoppingListDiv = document.createElement('div'); 
+  let shoppingListDiv = document.createElement('div');
   //set up shopping list
   shoppingListDiv.id = 'shopping-list';
   shoppingListDiv.style.margin = '40px auto';
   shoppingListDiv.style.width = '400px';
   shoppingListDiv.innerHTML =
-  '<style> #shopping-list li { margin-top: 5px; padding: 5px 3px; border: 1px solid black; list-style: none;}</style>' +
+  '<style>' +
+  '  #shopping-list ul { padding: 0; }' +
+  '  #shopping-list li { margin-top: 5px; padding: 5px 3px; border: 1px solid black; list-style: none; }' +
+  '  li#yogurt { padding: 15px 160px; border: 5px solid black; margin-top: 25px; }' +
+  '</style>' +
   '<ul>' +
   '  <li>This is an example list for the sake of having some UI to point to.</li>' +
   '  <li id="milk">Milk</li>' +

--- a/test/es/helpers/placement.js
+++ b/test/es/helpers/placement.js
@@ -5,6 +5,12 @@ const PLACEMENT_LEFT = 'left';
 const PLACEMENT_RIGHT = 'right';
 const QUERY_SELECTOR_CALLOUT = '.hopscotch-bubble';
 const QUERY_SELECTOR_ARROW = '.hopscotch-bubble-arrow-container';
+const PLACEMENT_DEVIATION = 1;
+
+function hasExpectedPlacement(actual, expected) {
+  let diff = Math.abs(actual - expected);
+  return diff <= PLACEMENT_DEVIATION;
+}
 
 function isPlacedOnTop(calloutPos, arrowEl, targetPos) {
   // placement: top
@@ -17,7 +23,10 @@ function isPlacedOnTop(calloutPos, arrowEl, targetPos) {
   //         _______________
   //        |   Target      |
   //        |_______________|
-  return Math.round(calloutPos.bottom + arrowEl.offsetHeight) === Math.round(targetPos.top);
+  let actualPlacement = Math.floor(calloutPos.bottom + arrowEl.offsetHeight);
+  let expectedPlacement = Math.floor(targetPos.top);
+
+  return hasExpectedPlacement(actualPlacement, expectedPlacement);
 }
 
 function isPlacedOnBottom(calloutPos, arrowEl, targetPos) {
@@ -31,7 +40,10 @@ function isPlacedOnBottom(calloutPos, arrowEl, targetPos) {
   //        ----------------
   //        |   Callout    |
   //        ----------------
-  return Math.round(calloutPos.top - arrowEl.offsetHeight) === Math.round(targetPos.bottom);
+  let actualPlacement = Math.floor(calloutPos.top - arrowEl.offsetHeight);
+  let expectedPlacement = Math.round(targetPos.bottom);
+
+  return hasExpectedPlacement(actualPlacement, expectedPlacement);
 }
 
 function isPlacedOnLeft(calloutPos, arrowEl, targetPos) {
@@ -41,7 +53,10 @@ function isPlacedOnLeft(calloutPos, arrowEl, targetPos) {
   //        ----------------   ----------------
   //        |   Callout    |>  |   Target     |
   //        ----------------   ----------------
-  return Math.round(calloutPos.right + arrowEl.offsetWidth) === Math.round(targetPos.left);
+  let actualPlacement = Math.floor(calloutPos.right + arrowEl.offsetWidth);
+  let expectedPlacement = Math.floor(targetPos.left);
+
+  return hasExpectedPlacement(actualPlacement, expectedPlacement);
 }
 
 function isPlacedOnRight(calloutPos, arrowEl, targetPos) {
@@ -51,7 +66,10 @@ function isPlacedOnRight(calloutPos, arrowEl, targetPos) {
   //        ----------------   ----------------
   //        |   Target     | < |   Callout    |
   //        ----------------   ----------------
-  return Math.round(calloutPos.left - arrowEl.offsetWidth) === Math.round(targetPos.right);
+  let actualPlacement = Math.floor(calloutPos.left - arrowEl.offsetWidth);
+  let expectedPlacement = Math.floor(targetPos.right);
+
+  return hasExpectedPlacement(actualPlacement, expectedPlacement);
 }
 
 function verifyCalloutPlacement(target, expectedPlacement) {
@@ -78,22 +96,6 @@ function verifyCalloutPlacement(target, expectedPlacement) {
   } else {
     throw new Error('Callout element should exist in the DOM');
   }
-}
-
-function verifyCalloutIsShown() {
-  let hsCallout = document.querySelector(QUERY_SELECTOR_CALLOUT),
-    hsArrow = document.querySelector(QUERY_SELECTOR_ARROW);
-
-  expect(hsCallout).toBeDefined();
-  expect(hsArrow).toBeDefined();
-}
-
-function verifyCalloutIsNotShown() {
-  let hsCallout = document.querySelector(QUERY_SELECTOR_CALLOUT),
-    hsArrow = document.querySelector(QUERY_SELECTOR_ARROW);
-
-  expect(hsCallout).not.toBeDefined();
-  expect(hsArrow).not.toBeDefined();
 }
 
 /**
@@ -154,11 +156,14 @@ function verifyVerticalCentersAligned(el1, el2) {
 function verifyHorizontalOffset(el1, el2, expectedOffset, isRTL) {
   let el1Box = el1.getBoundingClientRect();
   let el2Box = el2.getBoundingClientRect();
+  let actualOffset;
   if (isRTL) {
-    expect(Math.floor(el1Box.right - el2Box.right)).toEqual(expectedOffset);
+    actualOffset = Math.floor(el1Box.right - el2Box.right);
   } else {
-    expect(Math.floor(el1Box.left - el2Box.left)).toEqual(expectedOffset);
+    actualOffset = Math.floor(el1Box.left - el2Box.left);
   }
+
+  expect(hasExpectedPlacement(actualOffset, expectedOffset)).toEqual(true);
 }
 
 /**
@@ -168,11 +173,13 @@ function verifyHorizontalOffset(el1, el2, expectedOffset, isRTL) {
 function verifyVerticalOffset(el1, el2, expectedOffset) {
   let el1Box = el1.getBoundingClientRect();
   let el2Box = el2.getBoundingClientRect();
-  expect(Math.floor(el1Box.top - el2Box.top)).toEqual(expectedOffset);
+  let actualOffset = Math.floor(el1Box.top - el2Box.top);
+
+  expect(hasExpectedPlacement(actualOffset, expectedOffset)).toEqual(true);
 }
 
 /**
- * Checks that callout is horizontally offset from target by an expected offset 
+ * Checks that callout is horizontally offset from target by an expected offset
  */
 function verifyXOffset(target, placement, expectedOffset, isRtl) {
   let callout = document.querySelector(QUERY_SELECTOR_CALLOUT);
@@ -202,11 +209,11 @@ function verifyXOffset(target, placement, expectedOffset, isRtl) {
     }
   }
 
-  expect(Math.floor(actualOffset)).toEqual(expectedOffset);
+  expect(hasExpectedPlacement(actualOffset, expectedOffset)).toEqual(true);
 }
 
 /**
- * Checks that callout is vertically offset from target by an expected offset 
+ * Checks that callout is vertically offset from target by an expected offset
  */
 function verifyYOffset(target, placement, expectedOffset) {
   let callout = document.querySelector(QUERY_SELECTOR_CALLOUT);
@@ -227,11 +234,12 @@ function verifyYOffset(target, placement, expectedOffset) {
       actualOffset = calloutElBox.top - targetElBox.top;
     }
   }
-  expect(Math.floor(actualOffset)).toEqual(expectedOffset);
+
+  expect(hasExpectedPlacement(actualOffset, expectedOffset)).toEqual(true);
 }
 
 /**
- * Checks that arrow has expected offset relative to the callout 
+ * Checks that arrow has expected offset relative to the callout
  */
 function verifyArrowOffset(placement, expectedOffset, isRTL) {
   let callout = document.querySelector(QUERY_SELECTOR_CALLOUT + ' .hopscotch-bubble-container');
@@ -254,8 +262,6 @@ function verifyArrowOffset(placement, expectedOffset, isRTL) {
 
 let PlacementTestUtils = {
   verifyCalloutPlacement,
-  verifyCalloutIsShown,
-  verifyCalloutIsNotShown,
   ensurePageScroll,
   resetPageScroll,
   verifyXOffset,


### PR DESCRIPTION
This pull request resolves #230.

`width` and `height` from `getBoundingCleintRect` is the same as `offsetWidth` and `offsetHeight`. The only caveat is that `width` and `height` were added to the `getBoundingCleintRect` starting with IE9. There are no differences with respect to border width and padding, though I have updated fixture setup to add extra border and padding to one of the test targets. 

I've updated PlacementManager to consistently use width and height from clientBoundingRect (given that we are not supporting anything older than IE9).

Also updated placement test utils to allow for 1px deviation in placement. Some of the unit tests were failing in Firefox and IE because of differences in rounding of top\left\width and height values.

Ran these unit tests in latest Chrome, Firefox, Safari 8, IE9, 10 and 11. All unit tests pass with these changes.