### PR TITLE
Add postcss with autoprefixer into the build pipeline. Resolves #232

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -316,6 +316,17 @@ module.exports = function (grunt) {
           "destination": "<%=paths.build%>/esdoc"
         }
       }
+    },
+    postcss: {
+      options: {
+        map: false,
+        processors: [
+          require('autoprefixer')({ browsers: 'last 2 versions, ie 9, ie 10, ie 11' }) // https://github.com/ai/browserslist
+        ]
+      },
+      dist: {
+        src: '<%=paths.build%>/css/*.css'
+      }
     }
   });
   
@@ -335,6 +346,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-browserify');
   grunt.loadNpmTasks('grunt-eslint');
   grunt.loadNpmTasks('grunt-esdoc');
+  grunt.loadNpmTasks('grunt-postcss');
 
   grunt.registerMultiTask('log', 'Print some messages', function () {
     grunt.log.ok(this.data.options.message);
@@ -344,7 +356,7 @@ module.exports = function (grunt) {
   grunt.registerTask(
     'buildES',
     'Build hopscotch for testing (jshint, minify js, process less to css)',
-    ['clean:build', 'copy:build', 'eslint', 'jst:compile', 'babel', 'browserify', 'includereplace:esSource', 'less', 'esdoc']
+    ['clean:build', 'copy:build', 'eslint', 'jst:compile', 'babel', 'browserify', 'includereplace:esSource', 'less', 'esdoc', 'postcss']
     );
 
   grunt.registerTask(

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "url": "https://github.com/linkedin/hopscotch/issues"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
+    "autoprefixer": "^6.0.3",
+    "grunt": "^0.4.5",
     "grunt-babel": "^5.0.3",
     "grunt-browserify": "^4.0.1",
     "grunt-bump": "~0.0.13",
@@ -30,13 +31,14 @@
     "grunt-contrib-jasmine": "^0.8.1",
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-jst": "~0.6.0",
-    "grunt-contrib-less": "~0.9.0",
+    "grunt-contrib-less": "^1.0.1",
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-esdoc": "~0.0.2",
     "grunt-eslint": "^17.2.0",
     "grunt-include-replace": "~1.2.0",
+    "grunt-postcss": "^0.7.0",
     "grunt-template-jasmine-istanbul": "^0.3.0",
-    "jquery": "~2.1.0",
-    "grunt-esdoc": "~0.0.2"
+    "jquery": "~2.1.0"
   }
 }

--- a/src/less/buttons.less
+++ b/src/less/buttons.less
@@ -1,5 +1,4 @@
 div.hopscotch-bubble .hopscotch-nav-button {
-  /* borrowed from katy styles */
   font-weight:bold;
   border-width:1px;
   border-style:solid;
@@ -12,32 +11,24 @@ div.hopscotch-bubble .hopscotch-nav-button {
   height:26px;
   line-height:24px;
   font-size:12px;
-  *zoom:1;
   white-space:nowrap;
-  display:-moz-inline-stack;
   display:inline-block;
   vertical-align:middle;
-  *vertical-align:auto;
-  zoom:1;
-  *display:inline;
-  vertical-align:middle;
-
-  .round-corners(3px);
-  .box-sizing();
+  border-radius: 3px;
+  box-sizing: border-box;
 
   &:hover {
-    *zoom:1;
-    .box-shadow(0, 1px, 3px, rgba(0,0,0,0.25), false);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.25); 
   }
 
   &:active {
-    .box-shadow(0, 1px, 2px, rgba(0,0,0,0.25), true);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.25) inset;
   }
 
   &.next {
     border-color: #1b5480;
     color: #fff;
-    margin: 0 0 0 10px; /* HS specific*/
+    margin: 0 0 0 10px;
     text-shadow: 0 1px 1px rgba(0,0,0,0.35);
     .gradient(#287bbc, #287bbc, #23639a);
 
@@ -56,11 +47,7 @@ div.hopscotch-bubble .hopscotch-nav-button {
     &:hover {
       background-color:#e8e8e8;
       filter:progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFE8E8E8', endColorstr='#FFA9A9A9');
-      background-image:-webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #e8e8e8), color-stop(13%, #e3e3e3), color-stop(32%, #d7d7d7), color-stop(71%, #b9b9b9), color-stop(100%, #a9a9a9));
-      background-image:-webkit-linear-gradient(top, #e8e8e8 0%,#e3e3e3 13%,#d7d7d7 32%,#b9b9b9 71%,#a9a9a9 100%);
-      background-image:-moz-linear-gradient(top, #e8e8e8 0%,#e3e3e3 13%,#d7d7d7 32%,#b9b9b9 71%,#a9a9a9 100%);
-      background-image:-o-linear-gradient(top, #e8e8e8 0%,#e3e3e3 13%,#d7d7d7 32%,#b9b9b9 71%,#a9a9a9 100%);
-      background-image:linear-gradient(top, #e8e8e8 0%,#e3e3e3 13%,#d7d7d7 32%,#b9b9b9 71%,#a9a9a9 100%);
+      background-image:linear-gradient(to bottom, #e8e8e8 0%,#e3e3e3 13%,#d7d7d7 32%,#b9b9b9 71%,#a9a9a9 100%);
     }
   }
 }

--- a/src/less/core.less
+++ b/src/less/core.less
@@ -7,31 +7,14 @@ div.hopscotch-bubble {
   font-size: 13px;
   position: absolute;
   z-index: @bubbleZindex;
-  .box-sizing(content-box);
+  box-sizing: content-box;
+  background-clip: padding-box;
 
   * {
-    .box-sizing(content-box);
+    box-sizing: content-box;
   }
 
-  .background-clip;
-
   &.animate {
-    -moz-transition-property: top, left;
-    -moz-transition-duration: @anim-duration;
-    -moz-transition-timing-function: @anim-timing;
-
-    -ms-transition-property: top, left;
-    -ms-transition-duration: @anim-duration;
-    -ms-transition-timing-function: @anim-timing;
-
-    -o-transition-property: top, left;
-    -o-transition-duration: @anim-duration;
-    -o-transition-timing-function: @anim-timing;
-
-    -webkit-transition-property: top, left;
-    -webkit-transition-duration: @anim-duration;
-    -webkit-transition-timing-function: @anim-timing;
-
     transition-property: top, left;
     transition-duration: @anim-duration;
     transition-timing-function: @anim-timing;
@@ -81,8 +64,6 @@ div.hopscotch-bubble {
   }
 
   .hopscotch-bubble-close {
-    -webkit-appearance: none;
-    -moz-appearance: none;
     appearance: none;
     border: 0;
     color: #000;

--- a/src/less/fade.less
+++ b/src/less/fade.less
@@ -26,52 +26,8 @@
 @distance: 20px;
 
 .animated {
-  -webkit-animation-fill-mode: both;
-  -moz-animation-fill-mode: both;
-  -ms-animation-fill-mode: both;
-  -o-animation-fill-mode: both;
   animation-fill-mode: both;
-  -webkit-animation-duration: @anim-duration;
-  -moz-animation-duration: @anim-duration;
-  -ms-animation-duration: @anim-duration;
-  -o-animation-duration: @anim-duration;
   animation-duration: @anim-duration;
-}
-
-@-webkit-keyframes fadeInUp {
-  0% {
-    opacity: 0;
-    -webkit-transform: translateY(@distance);
-  }
-
-  100% {
-    opacity: 1;
-    -webkit-transform: translateY(0);
-  }
-}
-
-@-moz-keyframes fadeInUp {
-  0% {
-    opacity: 0;
-    -moz-transform: translateY(@distance);
-  }
-
-  100% {
-    opacity: 1;
-    -moz-transform: translateY(0);
-  }
-}
-
-@-o-keyframes fadeInUp {
-  0% {
-    opacity: 0;
-    -o-transform: translateY(@distance);
-  }
-
-  100% {
-    opacity: 1;
-    -o-transform: translateY(0);
-  }
 }
 
 @keyframes fadeInUp {
@@ -87,46 +43,7 @@
 }
 
 .fade-in-up {
-  -webkit-animation-name: fadeInUp;
-  -moz-animation-name: fadeInUp;
-  -o-animation-name: fadeInUp;
   animation-name: fadeInUp;
-}
-
-@-webkit-keyframes fadeInDown {
-  0% {
-    opacity: 0;
-    -webkit-transform: translateY(-@distance);
-  }
-
-  100% {
-    opacity: 1;
-    -webkit-transform: translateY(0);
-  }
-}
-
-@-moz-keyframes fadeInDown {
-  0% {
-    opacity: 0;
-    -moz-transform: translateY(-@distance);
-  }
-
-  100% {
-    opacity: 1;
-    -moz-transform: translateY(0);
-  }
-}
-
-@-o-keyframes fadeInDown {
-  0% {
-    opacity: 0;
-    -ms-transform: translateY(-@distance);
-  }
-
-  100% {
-    opacity: 1;
-    -ms-transform: translateY(0);
-  }
 }
 
 @keyframes fadeInDown {
@@ -142,45 +59,7 @@
 }
 
 .fade-in-down {
-  -webkit-animation-name: fadeInDown;
-  -moz-animation-name: fadeInDown;
-  -o-animation-name: fadeInDown;
   animation-name: fadeInDown;
-}
-@-webkit-keyframes fadeInRight {
-  0% {
-    opacity: 0;
-    -webkit-transform: translateX(-@distance);
-  }
-
-  100% {
-    opacity: 1;
-    -webkit-transform: translateX(0);
-  }
-}
-
-@-moz-keyframes fadeInRight {
-  0% {
-    opacity: 0;
-    -moz-transform: translateX(-@distance);
-  }
-
-  100% {
-    opacity: 1;
-    -moz-transform: translateX(0);
-  }
-}
-
-@-o-keyframes fadeInRight {
-  0% {
-    opacity: 0;
-    -o-transform: translateX(-@distance);
-  }
-
-  100% {
-    opacity: 1;
-    -o-transform: translateX(0);
-  }
 }
 
 @keyframes fadeInRight {
@@ -196,45 +75,7 @@
 }
 
 .fade-in-right {
-  -webkit-animation-name: fadeInRight;
-  -moz-animation-name: fadeInRight;
-  -o-animation-name: fadeInRight;
   animation-name: fadeInRight;
-}
-@-webkit-keyframes fadeInLeft {
-  0% {
-    opacity: 0;
-    -webkit-transform: translateX(@distance);
-  }
-
-  100% {
-    opacity: 1;
-    -webkit-transform: translateX(0);
-  }
-}
-
-@-moz-keyframes fadeInLeft {
-  0% {
-    opacity: 0;
-    -moz-transform: translateX(@distance);
-  }
-
-  100% {
-    opacity: 1;
-    -moz-transform: translateX(0);
-  }
-}
-
-@-o-keyframes fadeInLeft {
-  0% {
-    opacity: 0;
-    -o-transform: translateX(@distance);
-  }
-
-  100% {
-    opacity: 1;
-    -o-transform: translateX(0);
-  }
 }
 
 @keyframes fadeInLeft {
@@ -250,9 +91,6 @@
 }
 
 .fade-in-left {
-  -webkit-animation-name: fadeInLeft;
-  -moz-animation-name: fadeInLeft;
-  -o-animation-name: fadeInLeft;
   animation-name: fadeInLeft;
 }
 

--- a/src/less/util.less
+++ b/src/less/util.less
@@ -1,48 +1,5 @@
-.round-corners (@radius: 5px) {
-  -moz-border-radius: @radius;
-  -ms-border-radius: @radius;
-  -o-border-radius: @radius;
-  -webkit-border-radius: @radius;
-  border-radius: @radius;
-}
-.background-clip () {
-  -moz-background-clip: padding; /* for Mozilla browsers*/
-  -webkit-background-clip: padding;   /* Webkit */
-  background-clip: padding-box; /*  browsers with full support */
-}
-.box-sizing(@sizing:border-box) {
-  -webkit-box-sizing: @sizing;
-  -moz-box-sizing: @sizing;
-  box-sizing: @sizing;
-}
 .gradient(@color, @start, @stop) {
   background-color: @color;
   filter:progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='@{start}', endColorstr='@{stop}');
-  background-image:-webkit-gradient(linear,
-                                    50% 0%,
-                                    50% 100%,
-                                    color-stop(0%, @start),
-                                    color-stop(100%, @stop));
-  background-image:-webkit-linear-gradient(top,
-                                           @start 0%,
-                                           @stop 100%);
-  background-image:-moz-linear-gradient(top,
-                                        @start 0%,
-                                        @stop 100%);
-  background-image:-o-linear-gradient(top,
-                                      @start 0%,
-                                      @stop 100%);
-  background-image:linear-gradient(top,
-                                   @start 0%,
-                                   @stop 100%);
-}
-.box-shadow(@x, @y, @blur, @color, @inset) when (@inset = true) {
-  -webkit-box-shadow: @x @y @blur @color inset;
-  -moz-box-shadow: @x @y @blur @color inset;
-  box-shadow: @x @y @blur @color inset; 
-}
-.box-shadow(@x, @y, @blur, @color, @inset) when (@inset = false) {
-  -webkit-box-shadow: @x @y @blur @color;
-  -moz-box-shadow: @x @y @blur @color;
-  box-shadow: @x @y @blur @color; 
+  background-image:linear-gradient(to bottom, @start 0%, @stop 100%);
 }


### PR DESCRIPTION
Adding postcss into build pipeline cleans up  source css significantly. Some of the vendor prefixes are no longer needed, since latest versions of evergreen browsers now fully support those properties without prefixes. Postcss adds vendor prefixes where necessary based on info from http://caniuse.com/

Here's a diff of the generated hopscotch.css file before and after the change https://www.diffchecker.com/wakxxypx

After this change there's is very little of LESS syntax left. What's left can be replaced with other postcss modules, like [postcss-import](https://github.com/postcss/postcss-import) to keep css modular,  [postcss-custom-properties](https://github.com/postcss/postcss-custom-properties) for variable support and [postcss-mixins](https://github.com/postcss/postcss-mixins) for mixin support.  We should consider making full switch to postcss.