### PR TITLE
Update jasmine version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "grunt-contrib-compress": "~0.6.0",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-copy": "~0.5.0",
-    "grunt-contrib-jasmine": "^0.8.1",
+    "grunt-contrib-jasmine": "^0.9.2",
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-jst": "~0.6.0",
     "grunt-contrib-less": "~0.9.0",


### PR DESCRIPTION
When building on a mac, I run into ENOENT error resulting in build failure, which is documented in issue 193 of the grunt-contrib-jasmine project (https://github.com/gruntjs/grunt-contrib-jasmine/issues/193). Updating the grunt-contrib-jasmine version to 0.9.2 solves it and I got a build success.