### PR TITLE
Fix scroll animation callback called twice #255

### DIFF
--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -1464,7 +1464,7 @@
 
         // Use jQuery if it exists
         else if (hasJquery) {
-          jQuery('body, html').animate({ scrollTop: scrollToVal }, getOption('scrollDuration'), cb);
+          jQuery('body').animate({ scrollTop: scrollToVal }, getOption('scrollDuration'), cb);
         }
 
         // Use my crummy setInterval scroll solution if we're using plain, vanilla Javascript.


### PR DESCRIPTION
See issue #255.

When showing a bubble on a target outside view, Hopscotch attempts to smooth scroll the target into view. Scrolling is attempted via the use of YUI or jQuery when available. This issue is related to how the scroll position is animated using jQuery.

jQuery calls the animation callback for each of the matched elements in the selector. Hopscotch was selecting **both** the `html` element **and** the `body` element for adjusting the `scrollTop` value, leading to the animation callback being called twice.

Adjusting `scrollTop` on the `html` element seems questionable anyway, so just removing it fixes the issue.