### PR TITLE
Avoid "Gradient has outdated direction syntax" error

### DIFF
--- a/src/less/buttons.less
+++ b/src/less/buttons.less
@@ -57,10 +57,10 @@ div.hopscotch-bubble .hopscotch-nav-button {
       background-color:#e8e8e8;
       filter:progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFE8E8E8', endColorstr='#FFA9A9A9');
       background-image:-webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #e8e8e8), color-stop(13%, #e3e3e3), color-stop(32%, #d7d7d7), color-stop(71%, #b9b9b9), color-stop(100%, #a9a9a9));
-      background-image:-webkit-linear-gradient(top, #e8e8e8 0%,#e3e3e3 13%,#d7d7d7 32%,#b9b9b9 71%,#a9a9a9 100%);
-      background-image:-moz-linear-gradient(top, #e8e8e8 0%,#e3e3e3 13%,#d7d7d7 32%,#b9b9b9 71%,#a9a9a9 100%);
-      background-image:-o-linear-gradient(top, #e8e8e8 0%,#e3e3e3 13%,#d7d7d7 32%,#b9b9b9 71%,#a9a9a9 100%);
-      background-image:linear-gradient(top, #e8e8e8 0%,#e3e3e3 13%,#d7d7d7 32%,#b9b9b9 71%,#a9a9a9 100%);
+      background-image:-webkit-linear-gradient(to bottom, #e8e8e8 0%,#e3e3e3 13%,#d7d7d7 32%,#b9b9b9 71%,#a9a9a9 100%);
+      background-image:-moz-linear-gradient(to bottom, #e8e8e8 0%,#e3e3e3 13%,#d7d7d7 32%,#b9b9b9 71%,#a9a9a9 100%);
+      background-image:-o-linear-gradient(to bottom, #e8e8e8 0%,#e3e3e3 13%,#d7d7d7 32%,#b9b9b9 71%,#a9a9a9 100%);
+      background-image:linear-gradient(to bottom, #e8e8e8 0%,#e3e3e3 13%,#d7d7d7 32%,#b9b9b9 71%,#a9a9a9 100%);
     }
   }
 }


### PR DESCRIPTION
Now hopscotch uses a bit outdated syntax. Please see https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient

Additionally, autoprefixer shows warnings about this.
> autoprefixer:  Gradient has outdated direction syntax. New syntax is like `to bottom` instead of `top`.

Please accept.
