### PR TITLE
[Chore] Refactor notice; Bump year

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,8 @@ Contributing to Hopscotch
 
 Thanks for taking the time to contribute back to Hopscotch! Below are some guidelines for how you can contribute to the project, including some details about how we triage bug reports and pull requests.
 
+> Note: We're currently in the midst of refactoring Hopscotch into a newer module-based format that should help make readability and maintenance a lot easier. While this work is in progress, we'll be halting changes to the master branch of Hopscotch, apart from major maintenance fixes. Please feel free to continue submitting bug reports, though do keep in mind that they not be addressed in the current iteration of the library. Thanks!
+
 Yikes! I found a bug! What now?
 -------------------------------
 We use GitHub for triaging new bugs. To help the community better understand the issue you've run into, check for the following...

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,7 +3,7 @@ module.exports = function(grunt) {
     pkg: grunt.file.readJSON('package.json'),
     banner : ['/**! <%=pkg.name%> - v<%=pkg.version%>',
         '*',
-        '* Copyright 2016 LinkedIn Corp. All rights reserved.',
+        '* Copyright 2017 LinkedIn Corp. All rights reserved.',
         '*',
         '* Licensed under the Apache License, Version 2.0 (the "License");',
         '* you may not use this file except in compliance with the License.',

--- a/README.md
+++ b/README.md
@@ -40,4 +40,6 @@ Depending on your use case, you might want to modify and/or rebuild some of the 
 
 I want to contribute! How can I help?
 -------------------------------------
+> Note: We're currently in the midst of refactoring Hopscotch into a newer module-based format that should help make readability and maintenance a lot easier. While this work is in progress, we'll be halting changes to the master branch of Hopscotch, apart from major maintenance fixes. Please feel free to continue submitting bug reports, though do keep in mind that they not be addressed in the current iteration of the library. Thanks!
+
 See CONTRIBUTING.md for details on how to contribute back to the public Hopscotch repository on GitHub.


### PR DESCRIPTION
Add a notice to README.md and CONTRIBUTING.md that clarifies the current state of Hopscotch development. While we're still happy to accept bug reports, feature requests, and PRs, I want to be clear about the fact that they may not get addressed for a while.

Also, bump year in Gruntfile.