### PR TITLE
Fix the rest of the deprecated gradient warnings

### DIFF
--- a/src/less/util.less
+++ b/src/less/util.less
@@ -23,16 +23,16 @@
                                     50% 100%,
                                     color-stop(0%, @start),
                                     color-stop(100%, @stop));
-  background-image:-webkit-linear-gradient(top,
+  background-image:-webkit-linear-gradient(to bottom,
                                            @start 0%,
                                            @stop 100%);
-  background-image:-moz-linear-gradient(top,
+  background-image:-moz-linear-gradient(to bottom,
                                         @start 0%,
                                         @stop 100%);
-  background-image:-o-linear-gradient(top,
+  background-image:-o-linear-gradient(to bottom,
                                       @start 0%,
                                       @stop 100%);
-  background-image:linear-gradient(top,
+  background-image:linear-gradient(to bottom,
                                    @start 0%,
                                    @stop 100%);
 }


### PR DESCRIPTION
Hey there,

#307 was a great start to fix the gradient warnings, but only fixed one instance. This change updates the gradient helper that gets used everywhere else, so this will fix gradient CSS warning throughout all of Hopscotch.

Fixes #232, #307

Thanks!