### PR TITLE
Calculate arrow offset without border

### DIFF
--- a/src/js/hopscotch.js
+++ b/src/js/hopscotch.js
@@ -665,7 +665,7 @@
       else if (step.placement === 'top' || step.placement === 'bottom') {
         arrowEl.style.top = '';
         if (arrowOffset === 'center') {
-          arrowEl.style[arrowPos] = Math.floor((bubbleBoundingWidth / 2) - arrowEl.offsetWidth/2) + 'px';
+          arrowEl.style[arrowPos] = Math.floor((el.clientWidth / 2) - arrowEl.offsetWidth/2) + 'px';
         }
         else {
           // Numeric pixel value
@@ -675,7 +675,7 @@
       else if (step.placement === 'left' || step.placement === 'right') {
         arrowEl.style[arrowPos] = '';
         if (arrowOffset === 'center') {
-          arrowEl.style.top = Math.floor((bubbleBoundingHeight / 2) - arrowEl.offsetHeight/2) + 'px';
+          arrowEl.style.top = Math.floor((el.clientHeight / 2) - arrowEl.offsetHeight/2) + 'px';
         }
         else {
           // Numeric pixel value


### PR DESCRIPTION
Fixing issue: #325 

Minimal example: http://fiddle.jshell.net/x62303x6/

Changes the arrow offset calculation to be calculated without border since the arrow is moved relative to the content bubble.

[el.offsetWidth & el.offsetHeight  => width + padding + border](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetHeight)
[el.clientWidth & el.clientHeight => height + padding](https://developer.mozilla.org/de/docs/Web/API/Element/clientHeight)

Therefor use clientWidth & clientHeight for the arrow offset instead of offsetWidth & offsetHeight.